### PR TITLE
fix(security): prevent stored XSS via uploaded SVG (#30)

### DIFF
--- a/frontend/src/lib/floor-map/SVGBackgroundNode.svelte
+++ b/frontend/src/lib/floor-map/SVGBackgroundNode.svelte
@@ -36,15 +36,25 @@
       height: (heightMatch ? parseInt(heightMatch[1]) : (data.height ?? 600)) * scale,
     };
   });
+
+  // Render the (user-uploaded) floor plan as an <img> data URI rather than
+  // inlining it with {@html}. An SVG loaded through <img> has scripting
+  // disabled by the browser, so an uploaded SVG containing <script> or on*
+  // event handlers cannot execute — this closes the stored-XSS vector (#30).
+  const svgDataUri = $derived(
+    data.svgContent
+      ? `data:image/svg+xml;utf8,${encodeURIComponent(data.svgContent)}`
+      : null,
+  );
 </script>
 
 <div
   class="svg-background-node"
   style="width: {svgDimensions.width}px; height: {svgDimensions.height}px;"
 >
-  {#if data.svgContent}
+  {#if svgDataUri}
     <div class="svg-container">
-      {@html data.svgContent}
+      <img class="svg-img" src={svgDataUri} alt="Floor plan" draggable="false" />
     </div>
   {:else}
     <div class="placeholder">
@@ -79,7 +89,7 @@
     opacity: 0.85;
   }
 
-  .svg-container :global(svg) {
+  .svg-img {
     width: 100%;
     height: 100%;
     display: block;

--- a/src/http/routes/floor_plan.rs
+++ b/src/http/routes/floor_plan.rs
@@ -117,6 +117,16 @@ pub async fn upload_floor_plan(
         return bad_request_response("Invalid SVG content. Must be a valid SVG document.");
     }
 
+    // Reject SVGs carrying active content (scripts / event handlers / embedded
+    // documents). The frontend also renders the plan via <img> (scripting
+    // disabled), so this is defense-in-depth at the upload boundary. See #30.
+    if !is_safe_svg(&upload.svg_content) {
+        warn!("Rejected floor plan upload containing active/executable SVG content");
+        return bad_request_response(
+            "SVG contains disallowed active content (scripts, event handlers, or embedded documents).",
+        );
+    }
+
     // Create floor plan model
     let floor_plan = FloorPlan::new(upload.svg_content);
 
@@ -175,6 +185,65 @@ fn is_valid_svg(content: &str) -> bool {
     has_closing
 }
 
+/// Reject SVGs carrying active/executable content. Defense-in-depth: the
+/// frontend renders the plan via `<img>` (which disables SVG scripting), but we
+/// also refuse obviously-malicious payloads at the upload boundary. See issue
+/// #30 (stored XSS via SVG upload).
+fn is_safe_svg(content: &str) -> bool {
+    let lower = content.to_ascii_lowercase();
+
+    const BANNED: &[&str] = &[
+        "<script",
+        "javascript:",
+        "<foreignobject",
+        "<iframe",
+        "<embed",
+        "<object",
+    ];
+    if BANNED.iter().any(|pat| lower.contains(pat)) {
+        return false;
+    }
+
+    !has_inline_event_handler(&lower)
+}
+
+/// Detect inline event-handler attributes such as `onload=`, `onclick=`, or
+/// `onbegin=` (SMIL), allowing whitespace before the `=`. Operates on an
+/// already-lowercased string.
+fn has_inline_event_handler(lower: &str) -> bool {
+    let bytes = lower.as_bytes();
+    for i in 0..bytes.len().saturating_sub(2) {
+        if bytes[i] != b'o' || bytes[i + 1] != b'n' {
+            continue;
+        }
+        // Must begin an attribute: preceded by a tag/attribute boundary.
+        let prev = if i == 0 { b' ' } else { bytes[i - 1] };
+        if !matches!(
+            prev,
+            b' ' | b'\t' | b'\n' | b'\r' | b'"' | b'\'' | b'<' | b'/'
+        ) {
+            continue;
+        }
+        // Consume the handler name (letters after "on").
+        let mut j = i + 2;
+        while j < bytes.len() && bytes[j].is_ascii_alphabetic() {
+            j += 1;
+        }
+        if j == i + 2 {
+            continue; // nothing after "on"
+        }
+        // Skip whitespace, then require '='.
+        let mut k = j;
+        while k < bytes.len() && matches!(bytes[k], b' ' | b'\t' | b'\n' | b'\r') {
+            k += 1;
+        }
+        if k < bytes.len() && bytes[k] == b'=' {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,5 +275,28 @@ mod tests {
         assert!(!is_valid_svg("not svg"));
         assert!(!is_valid_svg("<div></div>"));
         assert!(!is_valid_svg("<svg")); // no closing
+    }
+
+    #[test]
+    fn test_is_safe_svg_accepts_benign() {
+        assert!(is_safe_svg("<svg xmlns=\"http://www.w3.org/2000/svg\"><rect/></svg>"));
+        assert!(is_safe_svg(
+            "<svg><image href=\"data:image/png;base64,AAAA\"/></svg>"
+        ));
+        // "on" appearing in normal text/ids must not trip the handler detector.
+        assert!(is_safe_svg("<svg><text id=\"onion\">bacon</text></svg>"));
+    }
+
+    #[test]
+    fn test_is_safe_svg_rejects_active_content() {
+        assert!(!is_safe_svg("<svg><script>alert(1)</script></svg>"));
+        assert!(!is_safe_svg("<svg onload=\"alert(1)\"></svg>"));
+        assert!(!is_safe_svg("<svg onload = 'x'></svg>")); // whitespace before =
+        assert!(!is_safe_svg("<svg><rect onclick=\"x\"/></svg>"));
+        assert!(!is_safe_svg("<svg><a href=\"javascript:alert(1)\">x</a></svg>"));
+        assert!(!is_safe_svg("<svg><foreignObject><body/></foreignObject></svg>"));
+        assert!(!is_safe_svg(
+            "<svg><animate attributeName=\"x\" onbegin=\"alert(1)\"/></svg>"
+        ));
     }
 }


### PR DESCRIPTION
## Problem
Uploaded floor-plan SVGs were rendered inline with `{@html}` and the backend only checked for a `<svg>` tag (`floor_plan.rs` `is_valid_svg`). An SVG containing `<script>` or `on*` event handlers therefore executed in the app origin — **stored XSS** (issue #30).

## Fix (defense in depth)
- **Frontend** (`SVGBackgroundNode.svelte`): render the plan via `<img src="data:image/svg+xml,…">` instead of `{@html}`. SVGs loaded through `<img>` have scripting disabled by the browser, so embedded scripts/handlers cannot run. The plan is a visual backdrop (device nodes overlay separately via svelte-flow), so nothing is lost.
- **Backend** (`floor_plan.rs`): reject uploads with active content — `<script>`, inline `on*=` handlers (incl. SMIL `onbegin`), `javascript:`, `<foreignObject>`/`<iframe>`/`<embed>`/`<object>` — with a clear 400.

## Tests
Added unit tests for the SVG safety check (benign SVGs incl. embedded rasters pass; script/handler/foreignObject payloads are rejected). `cargo test` green; frontend builds.

Closes #30