### PR TITLE
feat(ui): consistent time format (#16) + emphasized 0°C line (#2)

### DIFF
--- a/frontend/src/lib/device-detail/PresenceDetailPage.svelte
+++ b/frontend/src/lib/device-detail/PresenceDetailPage.svelte
@@ -5,6 +5,7 @@
   import type { PresenceSensorReading } from "../api/sensors";
   import type { DeviceInfo, DeviceState } from "../types/devices";
   import { TIME_RANGE_HOURS } from "../stores/graphConfig";
+  import { formatTime } from "../utils/time";
   import StatusBadge from "../shared/StatusBadge.svelte";
   import Icon from "../design-system/Icon.svelte";
   import EditableDeviceName from "../devices/EditableDeviceName.svelte";
@@ -198,10 +199,7 @@
     yesterday.setDate(yesterday.getDate() - 1);
     const isYesterday = date.toDateString() === yesterday.toDateString();
 
-    const timeStr = date.toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    const timeStr = formatTime(date);
 
     if (isToday) return `Today ${timeStr}`;
     if (isYesterday) return `Yesterday ${timeStr}`;

--- a/frontend/src/lib/devices/SwitchCard.svelte
+++ b/frontend/src/lib/devices/SwitchCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SwitchDevice, AutomationRule } from "../api";
+  import { formatDateTime } from "../utils/time";
   import { fetchAutomationRules } from "../api";
   import { formatDistanceToNow } from "date-fns";
   import StatusBadge from "../shared/StatusBadge.svelte";
@@ -107,7 +108,7 @@
       <div class="device-id">{shortId}</div>
       <div
         class="last-update"
-        title={device.last_seen ? device.last_seen.toLocaleString() : "Never"}
+        title={device.last_seen ? formatDateTime(device.last_seen) : "Never"}
       >
         {displayTimeAgo}
       </div>

--- a/frontend/src/lib/graphs/GraphToolbar.svelte
+++ b/frontend/src/lib/graphs/GraphToolbar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { graphConfig } from "../stores/graphConfig";
   import type { GraphState } from "../stores/graphConfig";
+  import { hourCycle, useHour12 } from "../utils/time";
 
   let {
     metricType = "temperature"
@@ -10,6 +11,9 @@
 
   const currentMetric = $derived($graphConfig.metric);
   const currentTimeRange = $derived($graphConfig.timeRange);
+  const clock12 = $derived(
+    $hourCycle === "24h" ? false : $hourCycle === "12h" ? true : useHour12(),
+  );
 
   function setMetric(metric: GraphState['metric']) {
     graphConfig.setMetric(metric);
@@ -82,6 +86,28 @@
         onclick={() => setTimeRange('1y')}
       >
         1y
+      </button>
+    </div>
+  </div>
+
+  <div class="toolbar-divider"></div>
+
+  <div class="toolbar-section">
+    <span class="section-label">Clock:</span>
+    <div class="button-group">
+      <button
+        class="toolbar-btn"
+        class:active={!clock12}
+        onclick={() => hourCycle.set('24h')}
+      >
+        24h
+      </button>
+      <button
+        class="toolbar-btn"
+        class:active={clock12}
+        onclick={() => hourCycle.set('12h')}
+      >
+        12h
       </button>
     </div>
   </div>

--- a/frontend/src/lib/graphs/SensorGraph.svelte
+++ b/frontend/src/lib/graphs/SensorGraph.svelte
@@ -16,6 +16,7 @@
   } from "chart.js";
   import "chartjs-adapter-date-fns";
   import type { SensorReading } from "../api";
+  import { formatDateTime, timeToken, hourCycle } from "../utils/time";
 
   // Register Chart.js components
   Chart.register(
@@ -170,7 +171,7 @@
               title: (items) => {
                 if (items.length > 0 && items[0].parsed.x !== null) {
                   const date = new Date(items[0].parsed.x);
-                  return date.toLocaleString();
+                  return formatDateTime(date);
                 }
                 return "";
               },
@@ -189,7 +190,7 @@
             time: {
               tooltipFormat: "MMM d, HH:mm",
               displayFormats: {
-                hour: "HH:mm",
+                hour: timeToken(),
                 day: "MMM d",
               },
             },
@@ -215,7 +216,15 @@
               },
             },
             grid: {
-              color: "rgba(0, 0, 0, 0.05)",
+              // Emphasize the 0°C freezing line on the temperature axis (#2).
+              color: (ctx: any) =>
+                ctx.tick?.value === 0 && !isPresenceSensor && selectedMetric !== "humidity"
+                  ? "rgba(37, 99, 235, 0.65)"
+                  : "rgba(0, 0, 0, 0.05)",
+              lineWidth: (ctx: any) =>
+                ctx.tick?.value === 0 && !isPresenceSensor && selectedMetric !== "humidity"
+                  ? 2
+                  : 1,
             },
             ticks: {
               font: {
@@ -301,6 +310,18 @@
   $effect(() => {
     if (chart && (readings || selectedMetric !== undefined)) {
       updateChart();
+    }
+  });
+
+  // Refresh axis labels when the clock-format preference changes (#16).
+  $effect(() => {
+    void $hourCycle; // reactive dependency
+    if (chart) {
+      const xAxis = chart.options.scales?.x as any;
+      if (xAxis?.time) {
+        xAxis.time.displayFormats = { hour: timeToken(), day: "MMM d" };
+        chart.update("none");
+      }
     }
   });
 </script>

--- a/frontend/src/lib/graphs/UnifiedChart.svelte
+++ b/frontend/src/lib/graphs/UnifiedChart.svelte
@@ -19,6 +19,7 @@
   import { TIME_RANGE_HOURS } from "../stores/graphConfig";
   import { sensorsMemory } from "../memory";
   import { coversRange } from "../memory/rangeSet";
+  import { chartTimeFormats, formatDateTime, hourCycle } from "../utils/time";
 
   // Register Chart.js components
   Chart.register(
@@ -295,33 +296,7 @@
     }
   });
 
-  function getTimeDisplayFormats(range: string) {
-    switch (range) {
-      case "24h":
-        return { minute: "HH:mm", hour: "HH:mm", day: "HH:mm" };
-      case "1w":
-        return { minute: "HH:mm", day: "MMM dd", hour: "HH:mm" };
-      case "1m":
-        return {
-          minute: "HH:mm",
-          hour: "HH:mm",
-          day: "MMM dd",
-          week: "MMM dd",
-        };
-      case "1y":
-        return {
-          minute: "HH:mm",
-          hour: "HH:mm",
-          day: "MMM dd",
-          month: "MMM yyyy",
-          week: "MMM yyyy",
-        };
-      default:
-        return { hour: "HH:mm", day: "MMM dd" };
-    }
-  }
-
-  function createChart() {
+    function createChart() {
     if (!canvas) return;
 
     const ctx = canvas.getContext("2d");
@@ -350,7 +325,7 @@
               title: (items) => {
                 if (items.length > 0 && items[0].parsed.x !== null) {
                   const date = new Date(items[0].parsed.x);
-                  return date.toLocaleString();
+                  return formatDateTime(date);
                 }
                 return "";
               },
@@ -384,7 +359,7 @@
             type: "time",
             time: {
               tooltipFormat: "PPpp",
-              displayFormats: getTimeDisplayFormats(timeRange),
+              displayFormats: chartTimeFormats(timeRange),
             },
             grid: {
               display: false,
@@ -409,7 +384,16 @@
               font: { size: 12 },
             },
             grid: {
-              color: "rgba(0, 0, 0, 0.05)",
+              // Emphasize the 0 line — notably the 0°C freezing mark on the
+              // temperature axis (#2). Kept subtle for power/humidity axes.
+              color: (ctx: any) =>
+                ctx.tick?.value === 0 && metricType !== "power" && metric !== "humidity"
+                  ? "rgba(37, 99, 235, 0.65)"
+                  : "rgba(0, 0, 0, 0.05)",
+              lineWidth: (ctx: any) =>
+                ctx.tick?.value === 0 && metricType !== "power" && metric !== "humidity"
+                  ? 2
+                  : 1,
             },
             ticks: {
               font: { size: 11 },
@@ -459,7 +443,7 @@
     // Update time display formats
     const xAxis = chart.options.scales?.x as any;
     if (xAxis?.time) {
-      xAxis.time.displayFormats = getTimeDisplayFormats(timeRange);
+      xAxis.time.displayFormats = chartTimeFormats(timeRange);
     }
 
     chart.update("none");
@@ -500,6 +484,19 @@
       createChart();
     } else {
       updateChart();
+    }
+  });
+
+  // Refresh axis labels when the clock-format preference changes (#16).
+  // (Tooltips call formatDateTime() live, so they update on their own.)
+  $effect(() => {
+    void $hourCycle; // reactive dependency
+    if (chart) {
+      const xAxis = chart.options.scales?.x as any;
+      if (xAxis?.time) {
+        xAxis.time.displayFormats = chartTimeFormats(timeRange);
+        chart.update("none");
+      }
     }
   });
 </script>

--- a/frontend/src/lib/system/ProcessHistoryGraph.svelte
+++ b/frontend/src/lib/system/ProcessHistoryGraph.svelte
@@ -13,6 +13,7 @@
   } from 'chart.js';
   import 'chartjs-adapter-date-fns';
   import { fetchProcessHistory, type ProcessMonitorEntry } from "../api";
+  import { formatDateTime } from "../utils/time";
 
   Chart.register(
     LineController,
@@ -167,7 +168,7 @@
             callbacks: {
               title: (items) => {
                 if (items.length > 0 && items[0].parsed.x !== null) {
-                  return new Date(items[0].parsed.x).toLocaleString();
+                  return formatDateTime(new Date(items[0].parsed.x));
                 }
                 return '';
               },

--- a/frontend/src/lib/system/ProcessTableView.svelte
+++ b/frontend/src/lib/system/ProcessTableView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { ProcessMonitorEntry } from "../api";
+  import { formatDateTime } from "../utils/time";
   import ProcessHistoryGraph from "./ProcessHistoryGraph.svelte";
 
   let {
@@ -84,7 +85,7 @@
                   {entry.status}
                 </span>
               </td>
-              <td class="timestamp">{new Date(entry.timestamp).toLocaleString()}</td>
+              <td class="timestamp">{formatDateTime(new Date(entry.timestamp))}</td>
             </tr>
             {#if isExpanded}
               <tr class="expanded-row">

--- a/frontend/src/lib/system/SystemMetricsView.svelte
+++ b/frontend/src/lib/system/SystemMetricsView.svelte
@@ -14,6 +14,7 @@
   import zoomPlugin from 'chartjs-plugin-zoom';
   import 'chartjs-adapter-date-fns';
   import type { StorageBreakdown, SystemMonitorEntry } from "../api";
+  import { formatDateTime } from "../utils/time";
   import StorageBreakdownChart from "./StorageBreakdownChart.svelte";
 
   Chart.register(
@@ -117,7 +118,7 @@
             callbacks: {
               title: (items) => {
                 if (items.length > 0 && items[0].parsed.x !== null) {
-                  return new Date(items[0].parsed.x).toLocaleString();
+                  return formatDateTime(new Date(items[0].parsed.x));
                 }
                 return '';
               },

--- a/frontend/src/lib/system/TopConsumersView.svelte
+++ b/frontend/src/lib/system/TopConsumersView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { TopConsumerEntry } from "../api";
+  import { formatDateTime } from "../utils/time";
   import ProcessHistoryGraph from "./ProcessHistoryGraph.svelte";
 
   let {
@@ -61,7 +62,7 @@
     <div class="header">
       <h3>Top {type === 'cpu' ? 'CPU' : 'RAM'} Consumers</h3>
       <div class="last-updated">
-        Last updated: {new Date(latestEntries[0].timestamp).toLocaleString()}
+        Last updated: {formatDateTime(new Date(latestEntries[0].timestamp))}
       </div>
     </div>
 

--- a/frontend/src/lib/utils/time.ts
+++ b/frontend/src/lib/utils/time.ts
@@ -12,3 +12,111 @@ export function parseUnixSeconds(seconds: number | null | undefined): Date | nul
   }
   return unixSecondsToDate(seconds);
 }
+
+// ============================================================================
+// Time-of-day formatting (issue #16)
+//
+// Time was displayed inconsistently across the app: Chart.js axes used 24h
+// (date-fns "HH:mm") while tooltips/tables used `toLocaleString()` (12h under
+// en-US). Everything now goes through these helpers so the format is uniform
+// and follows a single user preference (defaulting to the browser locale).
+// ============================================================================
+
+import { writable } from 'svelte/store';
+
+export type HourCycle = 'auto' | '12h' | '24h';
+
+const HOUR_CYCLE_KEY = 'homeAutomation:hourCycle';
+
+function loadHourCycle(): HourCycle {
+  try {
+    const v = localStorage.getItem(HOUR_CYCLE_KEY);
+    if (v === '12h' || v === '24h' || v === 'auto') return v;
+  } catch {
+    /* localStorage unavailable (SSR) */
+  }
+  return 'auto';
+}
+
+/** User-selected clock format. Persisted; drives every time display. */
+export const hourCycle = writable<HourCycle>(loadHourCycle());
+
+let currentHourCycle: HourCycle = loadHourCycle();
+hourCycle.subscribe((v) => {
+  currentHourCycle = v;
+  try {
+    localStorage.setItem(HOUR_CYCLE_KEY, v);
+  } catch {
+    /* ignore */
+  }
+});
+
+/** Whether the current locale uses a 12-hour clock. */
+function localeUses12h(): boolean {
+  try {
+    return (
+      new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).resolvedOptions().hour12 ?? false
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Effective 12h flag: `true`/`false` for explicit prefs, locale default for 'auto'. */
+export function useHour12(): boolean {
+  if (currentHourCycle === '12h') return true;
+  if (currentHourCycle === '24h') return false;
+  return localeUses12h();
+}
+
+/** Time only, e.g. "18:00" or "6:00 PM". */
+export function formatTime(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: useHour12(),
+  }).format(date);
+}
+
+/** Date + time, for tooltips and tables, e.g. "Jul 2, 2026, 18:00". */
+export function formatDateTime(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: useHour12(),
+  }).format(date);
+}
+
+/** Date only, e.g. "Jul 2, 2026". */
+export function formatDate(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+}
+
+/** date-fns token for the time-of-day part, respecting the hour-cycle pref. */
+export function timeToken(): string {
+  return useHour12() ? 'h:mm a' : 'HH:mm';
+}
+
+/** Chart.js (date-fns) time-axis display formats for a given range. */
+export function chartTimeFormats(range: string): Record<string, string> {
+  const t = timeToken();
+  switch (range) {
+    case '24h':
+      return { minute: t, hour: t, day: t };
+    case '1w':
+      return { minute: t, hour: t, day: 'MMM dd' };
+    case '1m':
+      return { minute: t, hour: t, day: 'MMM dd', week: 'MMM dd' };
+    case '1y':
+      return { minute: t, hour: t, day: 'MMM dd', week: 'MMM yyyy', month: 'MMM yyyy' };
+    default:
+      return { hour: t, day: 'MMM dd' };
+  }
+}


### PR DESCRIPTION
Closes #16 and #2.

## #16 — Standardize time display format
Time was inconsistent: Chart.js axes used 24h (`HH:mm`) while tooltips/tables used `toLocaleString()` (12h under en-US).

- New centralized helpers in `utils/time.ts`: `formatTime`, `formatDateTime`, `formatDate`, `timeToken`, `chartTimeFormats`, driven by a **single persisted `hourCycle` preference** (`auto` → browser locale, or `12h`/`24h`).
- Wired everywhere time is shown: sensor & energy charts (axis display formats + tooltips), system-monitor charts/tables, presence detail, switch card.
- Added a **24h/12h toggle** in the graph toolbar. Charts update live (tooltips read the preference at render time; axes refresh via an effect on the store).

## #2 — Make the 0°C line more visible
Temperature y-axis now renders the **0°C line thicker (2px) and in a distinct blue**; power/humidity axes keep the subtle grid. Implemented with Chart.js scriptable `grid.color`/`lineWidth` (no new dependency).

## Verification
`npm run build` green. Frontend-only change (no backend rebuild).