### PR TITLE
feat(ui): drop on/off sensors from sensors page (#13) + English nav wording

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -236,7 +236,7 @@
           class="nav-button"
           class:active={isOnConsommations}
         >
-          Consommations
+          Energy
         </a>
         <a
           href={"/#" + URI_FRONTEND.COMMANDER}

--- a/frontend/src/lib/devices/SensorListPanel.svelte
+++ b/frontend/src/lib/devices/SensorListPanel.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import CompactSensorCard from "./CompactSensorCard.svelte";
-  import PresenceCard from "./PresenceCard.svelte";
   import { graphConfig } from "../stores/graphConfig";
   import type { SensorReading } from "../api";
   import type { DeviceInfo } from "../api/devices";
@@ -16,13 +15,19 @@
       (cap) => cap.type === "sensor" && cap.sensor_type === "energy_meter"
     );
 
+  // Exclude binary on/off (presence) sensors from this page (issue #13)
+  const isBinarySensor = (device: DeviceInfo) =>
+    device.capabilities.some(
+      (cap) => cap.type === "sensor" && cap.sensor_type === "presence"
+    );
+
   const deviceMap = $derived(new Map(devices.map(d => [d.device_id, d])));
 
   // Only show non-energy-meter sensors
   const sensors = $derived(
     allSensors.filter(s => {
       const device = deviceMap.get(s.deviceId);
-      return device && !isEnergyMeter(device);
+      return device && !isEnergyMeter(device) && !isBinarySensor(device);
     })
   );
 
@@ -31,12 +36,6 @@
   // Get latest reading for each sensor
   function getLatestReading(deviceId: string): SensorReading | null {
     return latestByDevice[deviceId] ?? null;
-  }
-
-  // Check if sensor is a presence sensor
-  function isPresenceSensor(deviceId: string): boolean {
-    const reading = getLatestReading(deviceId);
-    return reading?.type === 'presence';
   }
 
   // Check if any sensors are selected
@@ -125,19 +124,11 @@
     <div class="sensor-grid">
       {#each sensors as sensor (sensor.deviceId)}
         {@const reading = getLatestReading(sensor.deviceId)}
-        {#if isPresenceSensor(sensor.deviceId)}
-          <PresenceCard
-            {sensor}
-            {editMode}
-            latestReading={reading?.type === 'presence' ? reading : null}
-          />
-        {:else}
-          <CompactSensorCard
-            {sensor}
-            {editMode}
-            latestReading={reading}
-          />
-        {/if}
+        <CompactSensorCard
+          {sensor}
+          {editMode}
+          latestReading={reading}
+        />
       {/each}
     </div>
   {/if}

--- a/frontend/src/routes/SensorsView.svelte
+++ b/frontend/src/routes/SensorsView.svelte
@@ -17,10 +17,16 @@
       (cap) => cap.type === "sensor" && cap.sensor_type === "energy_meter"
     );
 
+  // Filter: exclude binary on/off (presence) sensors from this page (#13)
+  const isBinarySensor = (device: DeviceInfo) =>
+    device.capabilities.some(
+      (cap) => cap.type === "sensor" && cap.sensor_type === "presence"
+    );
+
   // Initialize graphConfig with the correct sensors for this view
   function initializeGraphConfig(devices: DeviceInfo[]) {
     const sensorDevices = devices
-      .filter((d) => !isEnergyMeter(d))
+      .filter((d) => !isEnergyMeter(d) && !isBinarySensor(d))
       .map((s) => ({ deviceId: s.device_id, color: s.color }));
     graphConfig.initializeSensors(sensorDevices);
   }


### PR DESCRIPTION
Closes #13.

## #13 — Remove on/off sensors from the Sensors page
Binary on/off (presence) sensors cluttered the Sensors page and weren't visually distinct from continuous metrics. Rather than redesign them, they are now **removed from this page**:
- Filtered out by capability (`sensor_type === "presence"`) in `SensorsView` (graph + config) and `SensorListPanel` (list).
- Removed the now-dead `PresenceCard` rendering branch.
- Presence sensors remain available via their detail page.

## Wording
Nav label `Consommations` → **`Energy`** (consistent English). Route and internal identifiers kept as-is to avoid breaking links/bookmarks.

`npm run build` green. Frontend-only.