### PR TITLE
fix(ui): 0°C reference line in black instead of blue

### DIFF
--- a/frontend/src/lib/graphs/SensorGraph.svelte
+++ b/frontend/src/lib/graphs/SensorGraph.svelte
@@ -219,7 +219,7 @@
               // Emphasize the 0°C freezing line on the temperature axis (#2).
               color: (ctx: any) =>
                 ctx.tick?.value === 0 && !isPresenceSensor && selectedMetric !== "humidity"
-                  ? "rgba(37, 99, 235, 0.65)"
+                  ? "rgba(0, 0, 0, 0.8)"
                   : "rgba(0, 0, 0, 0.05)",
               lineWidth: (ctx: any) =>
                 ctx.tick?.value === 0 && !isPresenceSensor && selectedMetric !== "humidity"

--- a/frontend/src/lib/graphs/UnifiedChart.svelte
+++ b/frontend/src/lib/graphs/UnifiedChart.svelte
@@ -388,7 +388,7 @@
               // temperature axis (#2). Kept subtle for power/humidity axes.
               color: (ctx: any) =>
                 ctx.tick?.value === 0 && metricType !== "power" && metric !== "humidity"
-                  ? "rgba(37, 99, 235, 0.65)"
+                  ? "rgba(0, 0, 0, 0.8)"
                   : "rgba(0, 0, 0, 0.05)",
               lineWidth: (ctx: any) =>
                 ctx.tick?.value === 0 && metricType !== "power" && metric !== "humidity"


### PR DESCRIPTION
Follow-up to #2: keep the emphasized 2px 0°C line but render it in strong black (`rgba(0,0,0,0.8)`) rather than blue, so it reads as a neutral reference rather than a data series.