### PR TITLE
fix(ui): 0°C reference line in gray

### DIFF
--- a/frontend/src/lib/graphs/SensorGraph.svelte
+++ b/frontend/src/lib/graphs/SensorGraph.svelte
@@ -219,7 +219,7 @@
               // Emphasize the 0°C freezing line on the temperature axis (#2).
               color: (ctx: any) =>
                 ctx.tick?.value === 0 && !isPresenceSensor && selectedMetric !== "humidity"
-                  ? "rgba(0, 0, 0, 0.8)"
+                  ? "rgba(107, 114, 128, 0.9)"
                   : "rgba(0, 0, 0, 0.05)",
               lineWidth: (ctx: any) =>
                 ctx.tick?.value === 0 && !isPresenceSensor && selectedMetric !== "humidity"

--- a/frontend/src/lib/graphs/UnifiedChart.svelte
+++ b/frontend/src/lib/graphs/UnifiedChart.svelte
@@ -388,7 +388,7 @@
               // temperature axis (#2). Kept subtle for power/humidity axes.
               color: (ctx: any) =>
                 ctx.tick?.value === 0 && metricType !== "power" && metric !== "humidity"
-                  ? "rgba(0, 0, 0, 0.8)"
+                  ? "rgba(107, 114, 128, 0.9)"
                   : "rgba(0, 0, 0, 0.05)",
               lineWidth: (ctx: any) =>
                 ctx.tick?.value === 0 && metricType !== "power" && metric !== "humidity"


### PR DESCRIPTION
Follow-up: render the emphasized 0°C line in gray (`rgba(107,114,128,.9)`) instead of black, keeping the 2px width.