### PR TITLE
feat(automation): variables in rules (#7)

### DIFF
--- a/frontend/src/lib/api/automation.ts
+++ b/frontend/src/lib/api/automation.ts
@@ -19,6 +19,9 @@ export interface AutomationCondition {
   field: AutomationConditionField;
   operator: ComparisonOperator;
   value: number;
+  /** When set (with target_field), compare against this device's field instead of `value` (#7). */
+  target_device_id?: string;
+  target_field?: AutomationConditionField;
 }
 
 export interface AutomationAction {
@@ -65,7 +68,9 @@ export interface CreateAutomationRuleRequest {
     device_id: string;
     field: AutomationConditionField;
     operator: ComparisonOperator;
-    value: number;
+    value?: number;
+    target_device_id?: string;
+    target_field?: AutomationConditionField;
   }>;
   actions: Array<{
     device_id: string;
@@ -83,7 +88,9 @@ export interface UpdateAutomationRuleRequest {
     device_id: string;
     field: AutomationConditionField;
     operator: ComparisonOperator;
-    value: number;
+    value?: number;
+    target_device_id?: string;
+    target_field?: AutomationConditionField;
   }>;
   actions?: Array<{
     device_id: string;

--- a/frontend/src/lib/automation/RuleEditor.svelte
+++ b/frontend/src/lib/automation/RuleEditor.svelte
@@ -50,6 +50,9 @@
     field: AutomationConditionField;
     operator: ComparisonOperator;
     value: number;
+    // Variable target (#7): when set, compare against another sensor's field.
+    target_device_id?: string;
+    target_field?: AutomationConditionField;
   }
 
   let conditionIdCounter = $state(rule?.conditions.length ?? 0);
@@ -60,6 +63,8 @@
       field: c.field,
       operator: c.operator,
       value: c.value,
+      target_device_id: c.target_device_id,
+      target_field: c.target_field,
     })) || []
   );
 
@@ -190,6 +195,21 @@
 
   function removeCondition(id: number) {
     conditions = conditions.filter((c) => c.id !== id);
+  }
+
+  // Switch a condition between comparing to a constant value or another sensor (#7)
+  function setConditionMode(condition: ConditionForm, mode: "value" | "sensor") {
+    if (mode === "sensor") {
+      const deviceId =
+        condition.target_device_id ?? (availableSensors[0]?.device_id || "");
+      condition.target_device_id = deviceId;
+      const fields = deviceId ? getFieldsForDevice(deviceId) : [];
+      condition.target_field =
+        condition.target_field ?? (fields[0]?.value ?? condition.field);
+    } else {
+      condition.target_device_id = undefined;
+      condition.target_field = undefined;
+    }
   }
 
   function addAction() {
@@ -577,42 +597,90 @@
                   </div>
 
                   <div class="input-group">
-                    <label for="condition-value-{condition.id}">Value</label>
-
-                    {#if condition.field === 'illumination'}
-                      <!-- Special dropdown for illumination: "Dim" (0) or "Bright" (1) -->
-                      <select
-                        id="condition-value-{condition.id}"
-                        bind:value={condition.value}
-                        required
-                      >
-                        <option value={0}>Dim</option>
-                        <option value={1}>Bright</option>
-                      </select>
-                    {:else if condition.field === 'presence'}
-                      <!-- Special dropdown for presence: "Not Occupied" (0) or "Occupied" (1) -->
-                      <select
-                        id="condition-value-{condition.id}"
-                        bind:value={condition.value}
-                        required
-                      >
-                        <option value={0}>Not Occupied</option>
-                        <option value={1}>Occupied</option>
-                      </select>
-                    {:else}
-                      <!-- Regular numeric input for temperature, humidity, battery, link_quality -->
-                      <input
-                        id="condition-value-{condition.id}"
-                        type="number"
-                        step={condition.field === 'temperature' ||
-                        condition.field === 'humidity'
-                          ? '0.1'
-                          : '1'}
-                        bind:value={condition.value}
-                        required
-                      />
-                    {/if}
+                    <label for="condition-compare-{condition.id}">Compare to</label>
+                    <select
+                      id="condition-compare-{condition.id}"
+                      value={condition.target_device_id !== undefined ? 'sensor' : 'value'}
+                      onchange={(e) =>
+                        setConditionMode(
+                          condition,
+                          e.currentTarget.value as 'value' | 'sensor',
+                        )}
+                    >
+                      <option value="value">Value</option>
+                      <option value="sensor">Sensor</option>
+                    </select>
                   </div>
+
+                  {#if condition.target_device_id !== undefined}
+                    <!-- Variable target: compare against another sensor's field (#7) -->
+                    <div class="input-group">
+                      <label for="condition-target-sensor-{condition.id}">Target sensor</label>
+                      <select
+                        id="condition-target-sensor-{condition.id}"
+                        bind:value={condition.target_device_id}
+                        required
+                      >
+                        <option value="">Select sensor...</option>
+                        {#each availableSensors as sensor (sensor.device_id)}
+                          <option value={sensor.device_id}>
+                            {sensor.name || sensor.device_id}
+                          </option>
+                        {/each}
+                      </select>
+                    </div>
+
+                    <div class="input-group">
+                      <label for="condition-target-field-{condition.id}">Target field</label>
+                      <select
+                        id="condition-target-field-{condition.id}"
+                        bind:value={condition.target_field}
+                        required
+                      >
+                        {#each getFieldsForDevice(condition.target_device_id) as field (field.value)}
+                          <option value={field.value}>{field.label}</option>
+                        {/each}
+                      </select>
+                    </div>
+                  {:else}
+                    <div class="input-group">
+                      <label for="condition-value-{condition.id}">Value</label>
+
+                      {#if condition.field === 'illumination'}
+                        <!-- Special dropdown for illumination: "Dim" (0) or "Bright" (1) -->
+                        <select
+                          id="condition-value-{condition.id}"
+                          bind:value={condition.value}
+                          required
+                        >
+                          <option value={0}>Dim</option>
+                          <option value={1}>Bright</option>
+                        </select>
+                      {:else if condition.field === 'presence'}
+                        <!-- Special dropdown for presence: "Not Occupied" (0) or "Occupied" (1) -->
+                        <select
+                          id="condition-value-{condition.id}"
+                          bind:value={condition.value}
+                          required
+                        >
+                          <option value={0}>Not Occupied</option>
+                          <option value={1}>Occupied</option>
+                        </select>
+                      {:else}
+                        <!-- Regular numeric input for temperature, humidity, battery, link_quality -->
+                        <input
+                          id="condition-value-{condition.id}"
+                          type="number"
+                          step={condition.field === 'temperature' ||
+                          condition.field === 'humidity'
+                            ? '0.1'
+                            : '1'}
+                          bind:value={condition.value}
+                          required
+                        />
+                      {/if}
+                    </div>
+                  {/if}
                 </div>
 
                 <button

--- a/src/db/queries/automation.rs
+++ b/src/db/queries/automation.rs
@@ -57,15 +57,17 @@ impl Database {
         // Insert conditions
         for condition in &rule.conditions {
             conn.execute(
-                "INSERT INTO automation_conditions (id, rule_id, device_id, field, operator, value)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                "INSERT INTO automation_conditions (id, rule_id, device_id, field, operator, value, target_device_id, target_field)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                 params![
                     condition.id,
                     rule.id,
                     condition.device_id,
                     condition.field.to_db_string(),
                     condition.operator.to_db_string(),
-                    condition.value
+                    condition.value,
+                    condition.target_device_id,
+                    condition.target_field.as_ref().map(|f| f.to_db_string()),
                 ],
             )?;
         }
@@ -156,7 +158,7 @@ impl Database {
 
             // Get conditions for this rule
             let mut cond_stmt = conn.prepare(
-                "SELECT id, device_id, field, operator, value
+                "SELECT id, device_id, field, operator, value, target_device_id, target_field
                  FROM automation_conditions
                  WHERE rule_id = ?1",
             )?;
@@ -165,6 +167,14 @@ impl Database {
                 .query_map(params![id], |row| {
                     let field_str: String = row.get(2)?;
                     let operator_str: String = row.get(3)?;
+                    let target_field_str: Option<String> = row.get(6)?;
+                    let target_field = match target_field_str {
+                        Some(s) => Some(
+                            SensorField::from_db_string(&s)
+                                .ok_or_else(|| invalid_column_error(6, "target_field"))?,
+                        ),
+                        None => None,
+                    };
 
                     Ok(AutomationCondition {
                         id: row.get(0)?,
@@ -174,6 +184,8 @@ impl Database {
                         operator: ComparisonOperator::from_db_string(&operator_str)
                             .ok_or_else(|| invalid_column_error(3, "operator"))?,
                         value: row.get(4)?,
+                        target_device_id: row.get(5)?,
+                        target_field,
                     })
                 })?
                 .collect::<Result<Vec<_>>>()?;
@@ -304,15 +316,17 @@ impl Database {
         // Insert new conditions
         for condition in &rule.conditions {
             conn.execute(
-                "INSERT INTO automation_conditions (id, rule_id, device_id, field, operator, value)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                "INSERT INTO automation_conditions (id, rule_id, device_id, field, operator, value, target_device_id, target_field)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                 params![
                     condition.id,
                     rule.id,
                     condition.device_id,
                     condition.field.to_db_string(),
                     condition.operator.to_db_string(),
-                    condition.value
+                    condition.value,
+                    condition.target_device_id,
+                    condition.target_field.as_ref().map(|f| f.to_db_string()),
                 ],
             )?;
         }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -753,6 +753,12 @@ impl Database {
             [],
         )?;
 
+        // Variable-target columns (issue #7): when set, the condition compares
+        // against another device's field instead of the constant `value`.
+        // Nullable, so pre-existing conditions remain constant comparisons.
+        self.add_column_if_missing(conn, "automation_conditions", "target_device_id", "TEXT")?;
+        self.add_column_if_missing(conn, "automation_conditions", "target_field", "TEXT")?;
+
         // Create automation_actions table
         debug!("Creating automation_actions table if not exists");
         conn.execute(

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -772,6 +772,8 @@ mod tests {
                 field: SensorField::Temperature,
                 operator: ComparisonOperator::GreaterThan,
                 value: 25.0,
+                target_device_id: None,
+                target_field: None,
             }],
             actions: vec![AutomationAction {
                 id: "action1".to_string(),
@@ -868,6 +870,8 @@ mod tests {
             field: SensorField::Humidity,
             operator: ComparisonOperator::LessThan,
             value: 30.0,
+            target_device_id: None,
+            target_field: None,
         });
 
         db.update_automation_rule(&rule).unwrap();
@@ -894,6 +898,8 @@ mod tests {
                 field: SensorField::Temperature,
                 operator: ComparisonOperator::GreaterThan,
                 value: 25.0,
+                target_device_id: None,
+                target_field: None,
             }],
             actions: vec![AutomationAction {
                 id: "action1".to_string(),
@@ -1298,6 +1304,8 @@ mod tests {
                     field: SensorField::Temperature,
                     operator: ComparisonOperator::GreaterThan,
                     value: 25.0,
+                    target_device_id: None,
+                    target_field: None,
                 },
                 AutomationCondition {
                     id: "cond2".to_string(),
@@ -1305,6 +1313,8 @@ mod tests {
                     field: SensorField::Humidity,
                     operator: ComparisonOperator::LessThan,
                     value: 40.0,
+                    target_device_id: None,
+                    target_field: None,
                 },
             ],
             actions: vec![

--- a/src/http/routes/automation.rs
+++ b/src/http/routes/automation.rs
@@ -42,80 +42,91 @@ pub fn serve_automation_rule(db: &Database, rule_id: &str) -> Response<Full<Byte
     }
 }
 
-/// Validate that automation conditions use fields compatible with their device types
+/// Validate that a single (device, field) pair is compatible with the device's
+/// sensor capabilities.
+fn validate_device_field(
+    db: &Database,
+    device_id: &str,
+    field: &crate::models::SensorField,
+) -> Result<(), String> {
+    // Get device from database
+    let device = db
+        .get_device(device_id)
+        .map_err(|e| format!("Database error: {}", e))?
+        .ok_or_else(|| format!("Device '{}' not found", device_id))?;
+
+    // Convert SensorField to string for comparison
+    let field_str = match field {
+        crate::models::SensorField::Temperature => "temperature",
+        crate::models::SensorField::Humidity => "humidity",
+        crate::models::SensorField::Battery => "battery",
+        crate::models::SensorField::LinkQuality => "link_quality",
+        crate::models::SensorField::Presence => "presence",
+        crate::models::SensorField::Illumination => "illumination",
+    };
+
+    let mut valid = false;
+    let mut valid_fields = Vec::new();
+
+    for capability in &device.capabilities {
+        if let DeviceCapability::Sensor { sensor_type } = capability {
+            match sensor_type {
+                SensorType::TempHumidity => {
+                    valid_fields.extend(["temperature", "humidity", "battery", "link_quality"]);
+                    if matches!(
+                        field_str,
+                        "temperature" | "humidity" | "battery" | "link_quality"
+                    ) {
+                        valid = true;
+                    }
+                }
+                SensorType::Presence => {
+                    valid_fields.extend(["presence", "illumination", "battery", "link_quality"]);
+                    if matches!(
+                        field_str,
+                        "presence" | "illumination" | "battery" | "link_quality"
+                    ) {
+                        valid = true;
+                    }
+                }
+                SensorType::EnergyMeter => {
+                    valid_fields.extend(["battery", "link_quality"]);
+                    if matches!(field_str, "battery" | "link_quality") {
+                        valid = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if valid_fields.is_empty() {
+        return Err(format!("Device '{}' is not a sensor", device_id));
+    }
+    valid_fields.sort_unstable();
+    valid_fields.dedup();
+
+    if !valid {
+        return Err(format!(
+            "Field '{}' is not valid for device '{}'. Valid fields: {}",
+            field_str,
+            device_id,
+            valid_fields.join(", ")
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate that automation conditions use fields compatible with their device
+/// types — including any variable target (#7).
 fn validate_condition_fields(
     db: &Database,
     conditions: &[AutomationCondition],
 ) -> Result<(), String> {
     for condition in conditions {
-        // Get device from database
-        let device = db
-            .get_device(&condition.device_id)
-            .map_err(|e| format!("Database error: {}", e))?
-            .ok_or_else(|| format!("Device '{}' not found", condition.device_id))?;
-
-        // Convert SensorField to string for comparison
-        let field_str = match condition.field {
-            crate::models::SensorField::Temperature => "temperature",
-            crate::models::SensorField::Humidity => "humidity",
-            crate::models::SensorField::Battery => "battery",
-            crate::models::SensorField::LinkQuality => "link_quality",
-            crate::models::SensorField::Presence => "presence",
-            crate::models::SensorField::Illumination => "illumination",
-        };
-
-        let mut valid = false;
-        let mut valid_fields = Vec::new();
-
-        for capability in &device.capabilities {
-            if let DeviceCapability::Sensor { sensor_type } = capability {
-                match sensor_type {
-                    SensorType::TempHumidity => {
-                        valid_fields.extend(["temperature", "humidity", "battery", "link_quality"]);
-                        if matches!(
-                            field_str,
-                            "temperature" | "humidity" | "battery" | "link_quality"
-                        ) {
-                            valid = true;
-                        }
-                    }
-                    SensorType::Presence => {
-                        valid_fields.extend([
-                            "presence",
-                            "illumination",
-                            "battery",
-                            "link_quality",
-                        ]);
-                        if matches!(
-                            field_str,
-                            "presence" | "illumination" | "battery" | "link_quality"
-                        ) {
-                            valid = true;
-                        }
-                    }
-                    SensorType::EnergyMeter => {
-                        valid_fields.extend(["battery", "link_quality"]);
-                        if matches!(field_str, "battery" | "link_quality") {
-                            valid = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        if valid_fields.is_empty() {
-            return Err(format!("Device '{}' is not a sensor", condition.device_id));
-        }
-        valid_fields.sort_unstable();
-        valid_fields.dedup();
-
-        if !valid {
-            return Err(format!(
-                "Field '{}' is not valid for device '{}'. Valid fields: {}",
-                field_str,
-                condition.device_id,
-                valid_fields.join(", ")
-            ));
+        validate_device_field(db, &condition.device_id, &condition.field)?;
+        if let Some((target_device_id, target_field)) = condition.variable_target() {
+            validate_device_field(db, target_device_id, target_field)?;
         }
     }
 
@@ -161,7 +172,7 @@ pub async fn create_automation_rule(
     let conditions: Vec<AutomationCondition> = request
         .conditions
         .into_iter()
-        .map(|c| AutomationCondition::new(c.device_id, c.field, c.operator, c.value))
+        .map(AutomationCondition::from)
         .collect();
 
     // Validate that condition fields are compatible with device types
@@ -272,7 +283,7 @@ pub async fn update_automation_rule(
         }
         let new_conditions: Vec<AutomationCondition> = conditions
             .into_iter()
-            .map(|c| AutomationCondition::new(c.device_id, c.field, c.operator, c.value))
+            .map(AutomationCondition::from)
             .collect();
 
         // Validate that condition fields are compatible with device types

--- a/src/models/automation.rs
+++ b/src/models/automation.rs
@@ -82,8 +82,19 @@ pub struct AutomationCondition {
     /// Comparison operator
     pub operator: ComparisonOperator,
 
-    /// Value to compare against
+    /// Constant value to compare against (used when no variable target is set)
     pub value: f64,
+
+    /// Optional "variable" target: another device to read the comparison value
+    /// from. When set together with `target_field`, the condition compares
+    /// `device_id.field` against `target_device_id.target_field` instead of the
+    /// constant `value`. (Issue #7 — variables in rules.)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_device_id: Option<String>,
+
+    /// Which field to read on `target_device_id` (see `target_device_id`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_field: Option<SensorField>,
 }
 
 impl AutomationCondition {
@@ -99,6 +110,31 @@ impl AutomationCondition {
             field,
             operator,
             value,
+            target_device_id: None,
+            target_field: None,
+        }
+    }
+
+    /// The variable target (device + field) if this condition compares against
+    /// another sensor rather than a constant.
+    pub fn variable_target(&self) -> Option<(&str, &SensorField)> {
+        match (&self.target_device_id, &self.target_field) {
+            (Some(device_id), Some(field)) => Some((device_id.as_str(), field)),
+            _ => None,
+        }
+    }
+}
+
+impl From<CreateConditionRequest> for AutomationCondition {
+    fn from(c: CreateConditionRequest) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            device_id: c.device_id,
+            field: c.field,
+            operator: c.operator,
+            value: c.value,
+            target_device_id: c.target_device_id,
+            target_field: c.target_field,
         }
     }
 }
@@ -255,7 +291,16 @@ pub struct CreateConditionRequest {
     pub device_id: String,
     pub field: SensorField,
     pub operator: ComparisonOperator,
+    /// Constant comparison value. Ignored (and may be omitted) when a variable
+    /// target is provided.
+    #[serde(default)]
     pub value: f64,
+    /// Optional variable target device (see `AutomationCondition`).
+    #[serde(default)]
+    pub target_device_id: Option<String>,
+    /// Optional variable target field.
+    #[serde(default)]
+    pub target_field: Option<SensorField>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -388,6 +433,45 @@ mod tests {
         }
 
         assert_eq!(LogicalOperator::from_db_string("invalid"), None);
+    }
+
+    #[test]
+    fn test_condition_variable_target() {
+        // Constant condition: no variable target.
+        let constant = AutomationCondition::new(
+            "sensor1".into(),
+            SensorField::Temperature,
+            ComparisonOperator::GreaterThan,
+            20.0,
+        );
+        assert!(constant.variable_target().is_none());
+
+        // Variable condition built from a request.
+        let cond: AutomationCondition = CreateConditionRequest {
+            device_id: "living_room".into(),
+            field: SensorField::Temperature,
+            operator: ComparisonOperator::GreaterThan,
+            value: 0.0,
+            target_device_id: Some("bedroom".into()),
+            target_field: Some(SensorField::Temperature),
+        }
+        .into();
+
+        match cond.variable_target() {
+            Some((device_id, field)) => {
+                assert_eq!(device_id, "bedroom");
+                assert_eq!(field, &SensorField::Temperature);
+            }
+            None => panic!("expected a variable target"),
+        }
+
+        // A target device id without a target field is not a variable target.
+        let partial = AutomationCondition {
+            target_device_id: Some("bedroom".into()),
+            target_field: None,
+            ..constant.clone()
+        };
+        assert!(partial.variable_target().is_none());
     }
 
     #[test]

--- a/src/services/automation.rs
+++ b/src/services/automation.rs
@@ -282,21 +282,19 @@ impl AutomationService {
             return false;
         }
 
-        // Collect all device IDs that require sensor readings from the database
-        let sensor_device_ids: Vec<String> = rule
-            .conditions
-            .iter()
-            .filter(|c| {
-                matches!(
-                    c.field,
-                    SensorField::Temperature
-                        | SensorField::Humidity
-                        | SensorField::Presence
-                        | SensorField::Illumination
-                )
-            })
-            .map(|c| c.device_id.clone())
-            .collect();
+        // Collect all device IDs that require sensor readings from the database —
+        // both each condition's own field and any variable target's field (#7).
+        let mut sensor_device_ids: Vec<String> = Vec::new();
+        for c in &rule.conditions {
+            if Self::is_reading_field(&c.field) {
+                sensor_device_ids.push(c.device_id.clone());
+            }
+            if let Some((target_device_id, target_field)) = c.variable_target() {
+                if Self::is_reading_field(target_field) {
+                    sensor_device_ids.push(target_device_id.to_string());
+                }
+            }
+        }
 
         // Batch query all sensor readings in a single database transaction
         let readings_cache = if !sensor_device_ids.is_empty() {
@@ -337,79 +335,103 @@ impl AutomationService {
         }
     }
 
+    /// Whether a field's value comes from the sensor readings cache (vs
+    /// device_state). Used to decide which device IDs to batch-fetch.
+    fn is_reading_field(field: &SensorField) -> bool {
+        matches!(
+            field,
+            SensorField::Temperature
+                | SensorField::Humidity
+                | SensorField::Presence
+                | SensorField::Illumination
+        )
+    }
+
+    /// Resolve the current numeric value of `field` for `device_id`, or `None`
+    /// if unavailable. Reading-based fields come from `readings_cache`; battery
+    /// and link quality come from the live device-state store.
+    fn resolve_field_value(
+        &self,
+        device_id: &str,
+        field: &SensorField,
+        readings_cache: &std::collections::HashMap<String, SensorReading>,
+    ) -> Option<f64> {
+        match field {
+            SensorField::Temperature => readings_cache.get(device_id).and_then(|reading| {
+                if let SensorReading::TempHumidity { temperature, .. } = reading {
+                    Some(*temperature as f64)
+                } else {
+                    None
+                }
+            }),
+            SensorField::Humidity => readings_cache.get(device_id).and_then(|reading| {
+                if let SensorReading::TempHumidity { humidity, .. } = reading {
+                    Some(*humidity as f64)
+                } else {
+                    None
+                }
+            }),
+            SensorField::Presence => readings_cache.get(device_id).and_then(|reading| {
+                if let SensorReading::Presence { occupied, .. } = reading {
+                    Some(if *occupied { 1.0 } else { 0.0 })
+                } else {
+                    None
+                }
+            }),
+            SensorField::Illumination => readings_cache.get(device_id).and_then(|reading| {
+                if let SensorReading::Presence { illumination, .. } = reading {
+                    illumination.as_ref().map(|ill| match ill.as_str() {
+                        "bright" => 1.0,
+                        "dim" => 0.0,
+                        _ => 0.0, // default to dim for unknown values
+                    })
+                } else {
+                    None
+                }
+            }),
+            SensorField::Battery => self.device_state.get_battery(device_id).map(|b| b as f64),
+            SensorField::LinkQuality => self
+                .device_state
+                .get_link_quality(device_id)
+                .map(|lq| lq as f64),
+        }
+    }
+
     fn evaluate_condition_with_cache(
         &self,
         condition: &AutomationCondition,
         readings_cache: &std::collections::HashMap<String, SensorReading>,
     ) -> bool {
-        let field_value = match condition.field {
-            SensorField::Temperature => {
-                readings_cache
-                    .get(&condition.device_id)
-                    .and_then(|reading| {
-                        if let SensorReading::TempHumidity { temperature, .. } = reading {
-                            Some(*temperature as f64)
-                        } else {
-                            None
-                        }
-                    })
-            }
-            SensorField::Humidity => readings_cache
-                .get(&condition.device_id)
-                .and_then(|reading| {
-                    if let SensorReading::TempHumidity { humidity, .. } = reading {
-                        Some(*humidity as f64)
-                    } else {
-                        None
-                    }
-                }),
-            SensorField::Presence => readings_cache
-                .get(&condition.device_id)
-                .and_then(|reading| {
-                    if let SensorReading::Presence { occupied, .. } = reading {
-                        Some(if *occupied { 1.0 } else { 0.0 })
-                    } else {
-                        None
-                    }
-                }),
-            SensorField::Illumination => {
-                readings_cache
-                    .get(&condition.device_id)
-                    .and_then(|reading| {
-                        if let SensorReading::Presence { illumination, .. } = reading {
-                            illumination.as_ref().map(|ill| match ill.as_str() {
-                                "bright" => 1.0,
-                                "dim" => 0.0,
-                                _ => 0.0, // default to dim for unknown values
-                            })
-                        } else {
-                            None
-                        }
-                    })
-            }
-            SensorField::Battery => self
-                .device_state
-                .get_battery(&condition.device_id)
-                .map(|b| b as f64),
-            SensorField::LinkQuality => self
-                .device_state
-                .get_link_quality(&condition.device_id)
-                .map(|lq| lq as f64),
+        let Some(left) =
+            self.resolve_field_value(&condition.device_id, &condition.field, readings_cache)
+        else {
+            debug!(
+                device_id = %condition.device_id,
+                field = ?condition.field,
+                "Automation condition field value unavailable"
+            );
+            return false;
         };
 
-        let value = match field_value {
-            Some(value) => value,
-            None => {
-                debug!(
-                    device_id = %condition.device_id,
-                    field = ?condition.field,
-                    "Automation condition field value unavailable"
-                );
-                return false;
+        // Right-hand side: another sensor's field (variable, #7) or the constant.
+        let right = match condition.variable_target() {
+            Some((target_device_id, target_field)) => {
+                match self.resolve_field_value(target_device_id, target_field, readings_cache) {
+                    Some(value) => value,
+                    None => {
+                        debug!(
+                            target_device_id = %target_device_id,
+                            target_field = ?target_field,
+                            "Automation condition variable target unavailable"
+                        );
+                        return false;
+                    }
+                }
             }
+            None => condition.value,
         };
 
-        condition.operator.evaluate(value, condition.value)
+        condition.operator.evaluate(left, right)
     }
 
     async fn execute_actions(&self, rule: &AutomationRule) -> Result<(), String> {


### PR DESCRIPTION
Closes #7.

Automation rule conditions can now compare a device's field against **another device's field** (e.g. `temperature > bedroom temperature`) instead of only a fixed value.

## How it works
A condition gains an optional variable target (`target_device_id` + `target_field`). When both are set, the comparison's right-hand side is resolved from that sensor at evaluation time; otherwise the constant `value` is used.

## Changes
- **model**: `AutomationCondition` gains optional `target_device_id`/`target_field` + `variable_target()`; `CreateConditionRequest` accepts them (`value` now optional). `From<CreateConditionRequest>`.
- **db**: two nullable columns on `automation_conditions` (migrated via `add_column_if_missing`); insert/select updated. Pre-existing conditions remain constant comparisons.
- **eval**: field resolution extracted to a reusable helper; target devices added to the batch readings fetch; RHS resolved from the target (fails closed if unavailable).
- **api**: validation also checks the target device supports its field.
- **frontend**: `RuleEditor` gets a "Compare to: Value | Sensor" toggle with target sensor + field pickers.

## Tests
`cargo test` green (142 + new `test_condition_variable_target`). Frontend builds.