### PR TITLE
feat(ui): unified sensor explorer + local mock backend

### DIFF
--- a/frontend/mock/data.ts
+++ b/frontend/mock/data.ts
@@ -1,0 +1,356 @@
+/**
+ * Fake data generators for local development (see mock/plugin.ts).
+ *
+ * Everything here is DETERMINISTIC for a given (deviceId, timestamp): the same
+ * timestamp always yields the same value. This matters because the frontend
+ * caches readings by time-range and refetches overlapping ranges — a
+ * non-deterministic generator would make points "jump" between requests.
+ *
+ * Response shapes mirror the Rust backend exactly (see src/models/*.rs and
+ * src/http/routes/sensors.rs):
+ *  - DeviceInfo: { device_id, name, capabilities[], available_fields[], color }
+ *  - SensorReading: internally tagged by "type", timestamp is unix SECONDS.
+ */
+
+export type SensorType = 'temp_humidity' | 'presence' | 'energy_meter';
+
+export interface MockDevice {
+  device_id: string;
+  name: string;
+  capabilities: Array<{ type: 'sensor'; sensor_type: SensorType }>;
+  available_fields: string[];
+  color: string | null;
+  // generation parameters (not serialized)
+  _seed: number;
+  _base?: number; // temp baseline / power baseline
+  _amp?: number; // diurnal amplitude
+}
+
+const AVAILABLE_FIELDS: Record<SensorType, string[]> = {
+  temp_humidity: ['temperature', 'humidity'],
+  presence: ['presence', 'illumination'],
+  energy_meter: [
+    'power',
+    'voltage',
+    'current',
+    'energy',
+    'produced_energy',
+    'ac_frequency',
+    'power_factor',
+  ],
+};
+
+function device(
+  device_id: string,
+  name: string,
+  sensor_type: SensorType,
+  color: string,
+  seed: number,
+  base?: number,
+  amp?: number,
+): MockDevice {
+  return {
+    device_id,
+    name,
+    capabilities: [{ type: 'sensor', sensor_type }],
+    available_fields: AVAILABLE_FIELDS[sensor_type],
+    color,
+    _seed: seed,
+    _base: base,
+    _amp: amp,
+  };
+}
+
+/** Catalogue of fake devices, one per (sensor type, room). */
+export const MOCK_DEVICES: MockDevice[] = [
+  // temp / humidity
+  device('0xmock000000000t1', 'Salon', 'temp_humidity', '#d62728', 11, 21, 2.5),
+  device('0xmock000000000t2', 'Chambre', 'temp_humidity', '#1f77b4', 22, 19, 1.8),
+  device('0xmock000000000t3', 'Extérieur', 'temp_humidity', '#2ca02c', 33, 12, 9),
+  device('0xmock000000000t4', 'Cuisine', 'temp_humidity', '#9467bd', 44, 22, 3),
+  // presence
+  device('0xmock000000000p1', 'Présence salon', 'presence', '#ffa600', 55),
+  device('0xmock000000000p2', 'Présence entrée', 'presence', '#ff7f0e', 66),
+  device('0xmock000000000p3', 'Présence bureau', 'presence', '#e377c2', 77),
+  // energy
+  device('0xmock000000000e1', 'Compteur général', 'energy_meter', '#17becf', 88, 220),
+  device('0xmock000000000e2', 'Prise bureau', 'energy_meter', '#8c564b', 99, 15),
+];
+
+const DAY = 86400;
+
+/** Deterministic pseudo-random in [0, 1) from an integer key. */
+function rand(key: number): number {
+  const x = Math.sin(key * 12.9898) * 43758.5453;
+  return x - Math.floor(x);
+}
+
+function hourOfDay(ts: number): number {
+  return ((ts % DAY) + DAY) % DAY / 3600; // 0..24
+}
+
+/** Diurnal curve peaking mid-afternoon (~15h), trough pre-dawn (~4h). */
+function diurnal(ts: number): number {
+  const h = hourOfDay(ts);
+  return Math.sin(((h - 9) / 24) * 2 * Math.PI);
+}
+
+function temperature(dev: MockDevice, ts: number): number {
+  const base = dev._base ?? 21;
+  const amp = dev._amp ?? 2;
+  const noise = (rand(Math.floor(ts / 600) + dev._seed) - 0.5) * 0.7;
+  return round(base + amp * diurnal(ts) + noise, 1);
+}
+
+function humidity(dev: MockDevice, ts: number): number {
+  // Inversely correlated with temperature, room-dependent offset.
+  const noise = (rand(Math.floor(ts / 600) + dev._seed * 3) - 0.5) * 4;
+  const v = 55 - 12 * diurnal(ts) + (dev._seed % 7) - 3 + noise;
+  return round(clamp(v, 28, 92), 1);
+}
+
+/** 30-minute occupancy blocks so bands read as contiguous, not confetti. */
+function occupied(dev: MockDevice, ts: number): boolean {
+  const block = Math.floor(ts / 1800) + dev._seed;
+  const h = hourOfDay(ts);
+  // Room-specific likelihood by time of day.
+  let prob: number;
+  if (dev.device_id.endsWith('p2')) {
+    // entrance: short spikes, mostly morning/evening
+    prob = h > 7 && h < 9 ? 0.5 : h > 18 && h < 21 ? 0.5 : 0.05;
+  } else if (dev.device_id.endsWith('p3')) {
+    // office: daytime working hours
+    prob = h > 9 && h < 18 ? 0.6 : 0.03;
+  } else {
+    // living room: evenings + weekend-ish daytime
+    prob = h > 17 && h < 24 ? 0.75 : h > 8 && h < 12 ? 0.4 : 0.05;
+  }
+  return rand(block) < prob;
+}
+
+function illumination(ts: number): string {
+  const h = hourOfDay(ts);
+  return h > 8 && h < 19 ? 'bright' : 'dark';
+}
+
+function power(dev: MockDevice, ts: number): number {
+  const base = dev._base ?? 30;
+  const h = hourOfDay(ts);
+  const dayMask = h > 7 && h < 23 ? 1 : 0.3;
+  const slot = Math.floor(ts / 900) + dev._seed; // 15-min slots
+  const r = rand(slot);
+  let spike = 0;
+  if (r > 0.85) spike = r * (dev._base && dev._base > 100 ? 1800 : 400);
+  else if (r > 0.6) spike = r * (dev._base && dev._base > 100 ? 300 : 60);
+  const noise = rand(slot * 7) * 8;
+  return round(Math.max(0, base + spike * dayMask + noise), 1);
+}
+
+function round(v: number, digits = 2): number {
+  const f = 10 ** digits;
+  return Math.round(v * f) / f;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+/** A serialized reading matching SensorReadingResponse on the frontend. */
+export type MockReading = Record<string, unknown> & { type: SensorType; timestamp: number };
+
+export function readingAt(dev: MockDevice, ts: number): MockReading {
+  const sensorType = dev.capabilities[0].sensor_type;
+  switch (sensorType) {
+    case 'temp_humidity':
+      return {
+        type: 'temp_humidity',
+        device_id: dev.device_id,
+        temperature: temperature(dev, ts),
+        humidity: humidity(dev, ts),
+        timestamp: ts,
+      };
+    case 'presence':
+      return {
+        type: 'presence',
+        device_id: dev.device_id,
+        occupied: occupied(dev, ts),
+        illumination: illumination(ts),
+        timestamp: ts,
+      };
+    case 'energy_meter': {
+      const p = power(dev, ts);
+      const voltage = round(230 + (rand(ts + dev._seed) - 0.5) * 6, 1);
+      return {
+        type: 'energy_meter',
+        device_id: dev.device_id,
+        power: p,
+        // Cumulative-ish energy that grows through the month then resets, so it
+        // stays in a plausible range instead of exploding with the unix epoch.
+        energy: round(((ts % (DAY * 30)) / DAY) * (dev._base ?? 30) * 0.02, 3),
+        produced_energy: 0,
+        voltage,
+        current: round(p / voltage, 3),
+        ac_frequency: 50,
+        power_factor: round(clamp(0.85 + rand(ts) * 0.14, 0, 1), 3),
+        timestamp: ts,
+      };
+    }
+  }
+}
+
+/**
+ * Generate a bucketed series for a device between [start, end] (unix seconds).
+ * Step is at least `bucket` (>= 60s), capped so a single response never
+ * exceeds ~2000 points — same spirit as the server-side aggregation.
+ */
+export function seriesFor(dev: MockDevice, start: number, end: number, bucket: number): MockReading[] {
+  const MAX_POINTS = 2000;
+  let step = Math.max(bucket || 60, 60);
+  const span = Math.max(0, end - start);
+  if (span / step > MAX_POINTS) {
+    step = Math.ceil(span / MAX_POINTS);
+  }
+  const out: MockReading[] = [];
+  const first = Math.ceil(start / step) * step;
+  for (let ts = first; ts <= end; ts += step) {
+    out.push(readingAt(dev, ts));
+  }
+  return out;
+}
+
+export function findDevice(deviceId: string): MockDevice | undefined {
+  return MOCK_DEVICES.find((d) => d.device_id === deviceId);
+}
+
+// ---------------------------------------------------------------------------
+// Floor plan: a fake apartment SVG + a star network topology + device
+// positions, so the Floor Plan tab is populated in mock mode too.
+// ---------------------------------------------------------------------------
+
+/** A neutral apartment layout (viewBox 0 0 900 700). */
+export const MOCK_FLOOR_PLAN_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 700" width="900" height="700">
+  <defs>
+    <pattern id="terrace" width="12" height="12" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="12" stroke="#bbf7d0" stroke-width="4" />
+    </pattern>
+  </defs>
+  <!-- rooms -->
+  <g fill="#f1f5f9" stroke="#94a3b8" stroke-width="3">
+    <rect x="20" y="20" width="450" height="280" />
+    <rect x="20" y="300" width="450" height="300" />
+    <rect x="470" y="20" width="410" height="300" />
+    <rect x="470" y="320" width="230" height="280" />
+    <rect x="700" y="320" width="180" height="280" />
+  </g>
+  <!-- terrace -->
+  <rect x="40" y="614" width="360" height="70" fill="#f0fdf4" stroke="#86efac" stroke-width="2" stroke-dasharray="8 6" />
+  <rect x="40" y="614" width="360" height="70" fill="url(#terrace)" opacity="0.5" />
+  <!-- outer wall -->
+  <rect x="20" y="20" width="860" height="580" fill="none" stroke="#475569" stroke-width="6" />
+  <!-- door openings (cover wall strokes) -->
+  <g fill="#f1f5f9">
+    <rect x="200" y="297" width="70" height="6" />
+    <rect x="467" y="150" width="6" height="70" />
+    <rect x="467" y="420" width="6" height="70" />
+    <rect x="697" y="430" width="6" height="70" />
+    <rect x="300" y="597" width="70" height="6" />
+  </g>
+  <!-- windows on exterior walls -->
+  <g stroke="#60a5fa" stroke-width="5">
+    <line x1="120" y1="20" x2="230" y2="20" />
+    <line x1="600" y1="20" x2="740" y2="20" />
+    <line x1="880" y1="120" x2="880" y2="220" />
+    <line x1="120" y1="600" x2="240" y2="600" />
+  </g>
+  <!-- labels -->
+  <g fill="#475569" font-family="system-ui, sans-serif" font-size="22" font-weight="600" text-anchor="middle">
+    <text x="245" y="165">Cuisine</text>
+    <text x="245" y="455">Salon</text>
+    <text x="675" y="175">Chambre</text>
+    <text x="585" y="465">Bureau</text>
+    <text x="790" y="465">Entrée</text>
+  </g>
+  <text x="220" y="656" fill="#4d7c0f" font-family="system-ui, sans-serif" font-size="18" font-weight="600" text-anchor="middle">Terrasse</text>
+</svg>`;
+
+const COORDINATOR_ID = '0xmock0000000cord';
+
+/** Device positions on the plan (top-left anchor, SVG coordinates). */
+const POSITIONS: Record<string, { x: number; y: number }> = {
+  [COORDINATOR_ID]: { x: 390, y: 40 },
+  '0xmock000000000t1': { x: 180, y: 410 }, // Salon
+  '0xmock000000000t2': { x: 610, y: 130 }, // Chambre
+  '0xmock000000000t3': { x: 180, y: 620 }, // Extérieur (terrasse)
+  '0xmock000000000t4': { x: 180, y: 120 }, // Cuisine
+  '0xmock000000000p1': { x: 260, y: 470 }, // Présence salon
+  '0xmock000000000p2': { x: 740, y: 430 }, // Présence entrée
+  '0xmock000000000p3': { x: 520, y: 430 }, // Présence bureau
+  '0xmock000000000e1': { x: 730, y: 520 }, // Compteur général (entrée)
+  '0xmock000000000e2': { x: 560, y: 370 }, // Prise bureau
+};
+
+/** Network topology: a coordinator with every sensor attached in a star. */
+export function mockTopology() {
+  const coordinator = {
+    id: COORDINATOR_ID,
+    mqtt_topic: 'coordinator',
+    ieee_addr: COORDINATOR_ID,
+    name: 'Coordinateur',
+    capabilities: [{ type: 'coordinator' as const }],
+    available_fields: [] as string[],
+    power_source: 'plugged' as const,
+    added_at: 1_700_000_000,
+    is_bridge: true,
+    parent_device_id: null,
+    color: '#334155',
+  };
+
+  const devices = MOCK_DEVICES.map((d) => {
+    const sensorType = d.capabilities[0].sensor_type;
+    return {
+      id: d.device_id,
+      mqtt_topic: d.name,
+      ieee_addr: d.device_id,
+      name: d.name,
+      capabilities: d.capabilities,
+      available_fields: d.available_fields,
+      power_source: (sensorType === 'energy_meter' ? 'plugged' : 'battery') as
+        | 'plugged'
+        | 'battery',
+      added_at: 1_700_000_000 + d._seed * 1000,
+      is_bridge: false,
+      parent_device_id: COORDINATOR_ID,
+      color: d.color,
+    };
+  });
+
+  const edges = MOCK_DEVICES.map((d) => ({
+    source_id: COORDINATOR_ID,
+    target_id: d.device_id,
+    link_quality: 110 + (d._seed % 100),
+  }));
+
+  return { devices: [coordinator, ...devices], edges };
+}
+
+/** Default device positions payload. */
+export function mockPositions(overrides: Record<string, { x: number; y: number }> = {}) {
+  const updated = Math.floor(Date.now() / 1000);
+  return Object.entries({ ...POSITIONS, ...overrides }).map(([device_id, p]) => ({
+    device_id,
+    x: p.x,
+    y: p.y,
+    updated_at: updated,
+  }));
+}
+
+/** DeviceInfo payload (strip generation params). */
+export function deviceInfo(dev: MockDevice) {
+  return {
+    device_id: dev.device_id,
+    name: dev.name,
+    capabilities: dev.capabilities,
+    available_fields: dev.available_fields,
+    color: dev.color,
+  };
+}

--- a/frontend/mock/plugin.ts
+++ b/frontend/mock/plugin.ts
@@ -1,0 +1,218 @@
+/**
+ * Vite dev-server plugin that fakes the Rust backend so the frontend can run
+ * fully standalone. Enabled only when VITE_MOCK is set (see `npm run dev:mock`).
+ *
+ *  - Intercepts every `/api/*` request and answers with generated JSON.
+ *  - Runs a WebSocket server on `/ws` that pushes live sensor readings, so the
+ *    "latest value" chips and sync indicator behave like production.
+ *
+ * It touches nothing in the production bundle: this file is only imported by
+ * vite.config.ts and only wired in when the env flag is on.
+ */
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Plugin, ViteDevServer } from 'vite';
+import { WebSocketServer, type WebSocket } from 'ws';
+import {
+  MOCK_DEVICES,
+  MOCK_FLOOR_PLAN_SVG,
+  deviceInfo,
+  mockPositions,
+  mockTopology,
+  readingAt,
+  seriesFor,
+  type MockReading,
+} from './data';
+
+// Session-scoped position overrides so dragging a device on the floor plan
+// sticks until the dev server restarts.
+const positionOverrides: Record<string, { x: number; y: number }> = {};
+
+const now = () => Math.floor(Date.now() / 1000);
+
+function json(res: ServerResponse, body: unknown, extraHeaders: Record<string, string> = {}) {
+  const payload = JSON.stringify(body);
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/json');
+  for (const [k, v] of Object.entries(extraHeaders)) res.setHeader(k, v);
+  res.end(payload);
+}
+
+function readBody(req: IncomingMessage, cb: (body: unknown) => void) {
+  let raw = '';
+  req.on('data', (chunk) => (raw += chunk));
+  req.on('end', () => {
+    try {
+      cb(raw ? JSON.parse(raw) : null);
+    } catch {
+      cb(null);
+    }
+  });
+}
+
+function deviceState(deviceId: string, seed: number) {
+  return {
+    device_id: deviceId,
+    battery_level: 60 + (seed % 40),
+    link_quality: 120 + (seed % 100),
+    last_seen: now() - (seed % 300),
+    turbo_mode: null,
+  };
+}
+
+function handleReadings(url: URL, res: ServerResponse) {
+  const q = url.searchParams;
+  const deviceId = q.get('device_id') ?? undefined;
+  const targets = deviceId ? MOCK_DEVICES.filter((d) => d.device_id === deviceId) : MOCK_DEVICES;
+
+  // latest=1 → one most-recent reading per device.
+  if (q.get('latest') === '1' || q.get('latest')?.toLowerCase() === 'true') {
+    const t = now();
+    const readings = targets.map((d) => readingAt(d, t));
+    return json(res, readings, { 'X-Latest-Timestamp': String(t) });
+  }
+
+  const bucket = Math.max(1, parseInt(q.get('bucket') ?? '1', 10) || 1);
+  let start: number;
+  let end: number;
+  const startParam = q.get('start');
+  const endParam = q.get('end');
+  if (startParam && endParam) {
+    start = parseInt(startParam, 10);
+    end = parseInt(endParam, 10);
+  } else {
+    const hours = parseInt(q.get('hours') ?? '24', 10) || 24;
+    end = now();
+    start = end - hours * 3600;
+  }
+
+  const readings: MockReading[] = [];
+  for (const d of targets) {
+    readings.push(...seriesFor(d, start, end, bucket));
+  }
+  const latest = readings.reduce((max, r) => Math.max(max, r.timestamp), end);
+  json(res, readings, { 'X-Latest-Timestamp': String(latest) });
+}
+
+function handleApi(req: IncomingMessage, res: ServerResponse): boolean {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const path = url.pathname;
+  const method = (req.method ?? 'GET').toUpperCase();
+
+  if (!path.startsWith('/api/')) return false;
+
+  // --- reads used by the sensor explorer -------------------------------
+  if (method === 'GET' && path === '/api/sensors') {
+    return json(res, MOCK_DEVICES.map(deviceInfo)), true;
+  }
+  if (method === 'GET' && path === '/api/readings') {
+    return handleReadings(url, res), true;
+  }
+  if (method === 'GET' && path === '/api/devices/state') {
+    return json(res, MOCK_DEVICES.map((d) => deviceState(d.device_id, d._seed))), true;
+  }
+
+  // --- floor plan tab --------------------------------------------------
+  if (method === 'GET' && path === '/api/floor-plan') {
+    return json(res, { svg_content: MOCK_FLOOR_PLAN_SVG, uploaded_at: now() }), true;
+  }
+  if (method === 'GET' && path === '/api/network/topology') {
+    return json(res, mockTopology()), true;
+  }
+  if (method === 'GET' && path === '/api/devices/positions') {
+    return json(res, mockPositions(positionOverrides)), true;
+  }
+  // Persist a dragged device position for this session.
+  if (method === 'PUT' && /^\/api\/devices\/.+\/position$/.test(path)) {
+    const deviceId = path.slice('/api/devices/'.length, -'/position'.length);
+    readBody(req, (body) => {
+      const { x, y } = (body ?? {}) as { x?: number; y?: number };
+      if (typeof x === 'number' && typeof y === 'number') {
+        positionOverrides[deviceId] = { x, y };
+      }
+      json(res, { ok: true });
+    });
+    return true;
+  }
+
+  // --- startup / other tabs: minimal but non-breaking answers ----------
+  if (method === 'GET' && path === '/api/devices/switches') return json(res, []), true;
+  if (method === 'GET' && path === '/api/automation/rules') return json(res, []), true;
+  if (method === 'GET' && path === '/api/automation/logs') return json(res, []), true;
+  if (method === 'GET' && path === '/api/system/storage') return json(res, {}), true;
+  if (method === 'GET' && path.startsWith('/api/logs/')) return json(res, []), true;
+
+  // --- writes: accept and echo success --------------------------------
+  if (method === 'POST' && path === '/api/commands/execute') return json(res, { ok: true }), true;
+  if (method === 'POST' && path === '/api/zigbee/permit_join') return json(res, { ok: true }), true;
+  if (method === 'POST' && path === '/api/network/refresh') return json(res, { ok: true }), true;
+  if (method === 'DELETE' && path === '/api/floor-plan') return json(res, { ok: true }), true;
+  if (method === 'PATCH' && path.startsWith('/api/devices/')) return json(res, { ok: true }), true;
+  if (method === 'PUT' && path.startsWith('/api/devices/')) return json(res, { ok: true }), true;
+
+  // Anything else under /api: safe empty payload so the UI never hard-fails.
+  json(res, []);
+  return true;
+}
+
+function setupWebSocket(server: ViteDevServer) {
+  const httpServer = server.httpServer;
+  if (!httpServer) return;
+
+  const wss = new WebSocketServer({ noServer: true });
+  const clients = new Set<WebSocket>();
+
+  httpServer.on('upgrade', (req, socket, head) => {
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    // Only claim /ws — let Vite's own HMR socket handle everything else.
+    if (url.pathname !== '/ws') return;
+    wss.handleUpgrade(req, socket as never, head, (ws) => {
+      clients.add(ws);
+      ws.on('close', () => clients.delete(ws));
+    });
+  });
+
+  // Push a live reading for a rotating device every few seconds.
+  let i = 0;
+  const timer = setInterval(() => {
+    if (clients.size === 0) return;
+    const dev = MOCK_DEVICES[i % MOCK_DEVICES.length];
+    i += 1;
+    const t = now();
+    const message = JSON.stringify({
+      event: 'sensor_reading',
+      device_id: dev.device_id,
+      reading: readingAt(dev, t),
+      timestamp: t,
+    });
+    for (const ws of clients) {
+      if (ws.readyState === ws.OPEN) ws.send(message);
+    }
+  }, 3000);
+
+  httpServer.on('close', () => {
+    clearInterval(timer);
+    wss.close();
+  });
+}
+
+export function mockBackend(): Plugin {
+  return {
+    name: 'mock-backend',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        try {
+          if (!handleApi(req, res)) next();
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error('[mock] error handling', req.url, err);
+          res.statusCode = 500;
+          res.end('mock error');
+        }
+      });
+      setupWebSocket(server);
+      // eslint-disable-next-line no-console
+      console.log('\n  🧪  Mock backend active — /api and /ws are served locally.\n');
+    },
+  };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,12 +20,14 @@
         "@sveltejs/vite-plugin-svelte": "^6.2.1",
         "@tsconfig/svelte": "^5.0.6",
         "@types/node": "^24.10.1",
+        "@types/ws": "^8.5.13",
         "svelte": "^5.43.8",
         "svelte-check": "^4.3.4",
         "terser": "^5.44.1",
         "typescript": "~5.9.3",
         "vite": "^7.2.4",
-        "vite-plugin-checker": "^0.12.0"
+        "vite-plugin-checker": "^0.12.0",
+        "ws": "^8.18.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -889,7 +891,6 @@
       "integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
         "debug": "^4.4.1",
@@ -997,9 +998,18 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@xyflow/svelte": {
@@ -1037,7 +1047,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1075,7 +1084,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -1195,7 +1203,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -1642,7 +1649,6 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.43.14.tgz",
       "integrity": "sha512-pHeUrp1A5S6RGaXhJB7PtYjL1VVjbVrJ2EfuAoPu9/1LeoMaJa/pcdCsCSb0gS4eUHAHnhCbUDxORZyvGK6kOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1705,7 +1711,6 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -1749,7 +1754,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1784,7 +1788,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -1941,6 +1944,28 @@
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "dev": "vite",
+    "dev:mock": "VITE_MOCK=1 vite",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.app.json"
@@ -14,12 +15,14 @@
     "@sveltejs/vite-plugin-svelte": "^6.2.1",
     "@tsconfig/svelte": "^5.0.6",
     "@types/node": "^24.10.1",
+    "@types/ws": "^8.5.13",
     "svelte": "^5.43.8",
     "svelte-check": "^4.3.4",
     "terser": "^5.44.1",
     "typescript": "~5.9.3",
     "vite": "^7.2.4",
-    "vite-plugin-checker": "^0.12.0"
+    "vite-plugin-checker": "^0.12.0",
+    "ws": "^8.18.0"
   },
   "dependencies": {
     "@xyflow/svelte": "^1.5.0",

--- a/frontend/src/lib/explorer/CategoryRail.svelte
+++ b/frontend/src/lib/explorer/CategoryRail.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+  import { slide } from "svelte/transition";
+  import { sensorsMemory } from "../memory";
+  import { explorerConfig } from "./explorerStore";
+  import {
+    CATEGORIES,
+    devicesForCategory,
+    formatMetricValue,
+    metricValue,
+    seriesKey,
+    type ExplorerMetric,
+  } from "./metrics";
+  import type { SensorReading } from "../api";
+
+  // Multiple sections can be open at once. Température is open by default.
+  let open = $state<Set<ExplorerMetric>>(new Set<ExplorerMetric>(["temperature"]));
+
+  const devices = $derived($sensorsMemory.devices);
+  const latestByDevice = $derived($sensorsMemory.latestByDevice);
+  const selected = $derived($explorerConfig.series);
+  const selectedKeys = $derived(new Set(selected.map((s) => seriesKey(s.deviceId, s.metric))));
+
+  const countByCategory = $derived.by(() => {
+    const counts: Record<string, number> = {};
+    for (const s of selected) counts[s.metric] = (counts[s.metric] ?? 0) + 1;
+    return counts;
+  });
+
+  function toggleSection(id: ExplorerMetric) {
+    const next = new Set(open);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    open = next;
+  }
+
+  function isSelected(deviceId: string, metric: ExplorerMetric) {
+    return selectedKeys.has(seriesKey(deviceId, metric));
+  }
+
+  function latestLabel(deviceId: string, metric: ExplorerMetric): string | null {
+    const reading = latestByDevice[deviceId] as SensorReading | null | undefined;
+    if (!reading) return null;
+    const v = metricValue(reading, metric);
+    return v === null ? null : formatMetricValue(v, metric);
+  }
+
+  function swatchColor(deviceId: string, metric: ExplorerMetric, fallback: string | null): string {
+    const s = selected.find((x) => x.deviceId === deviceId && x.metric === metric);
+    return s?.color ?? fallback ?? "#9ca3af";
+  }
+</script>
+
+<div class="accordion" role="group" aria-label="Catégories de capteurs">
+  {#each CATEGORIES as cat, i (cat.id)}
+    {@const isOpen = open.has(cat.id)}
+    {@const list = devicesForCategory(devices, cat.id)}
+    <section class="section" class:open={isOpen} class:first={i === 0}>
+      <button
+        class="head"
+        aria-expanded={isOpen}
+        onclick={() => toggleSection(cat.id)}
+      >
+        <svg class="icon" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+          <path d={cat.iconPath} />
+        </svg>
+        <span class="title">{cat.label}</span>
+        {#if countByCategory[cat.id]}
+          <span class="badge">{countByCategory[cat.id]}</span>
+        {/if}
+        <svg class="chevron" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {#if isOpen}
+        <div class="body" transition:slide={{ duration: 180 }}>
+          {#if list.length === 0}
+            <p class="empty">Aucun capteur.</p>
+          {:else}
+            {#each list as device (device.device_id)}
+              {@const sel = isSelected(device.device_id, cat.id)}
+              {@const value = latestLabel(device.device_id, cat.id)}
+              <button
+                class="row"
+                class:selected={sel}
+                onclick={() => explorerConfig.toggleSeries(device.device_id, cat.id, device.color)}
+                aria-pressed={sel}
+              >
+                <span
+                  class="dot"
+                  class:filled={sel}
+                  style={sel
+                    ? `background:${swatchColor(device.device_id, cat.id, device.color)};border-color:${swatchColor(device.device_id, cat.id, device.color)}`
+                    : ""}
+                ></span>
+                <span class="name">{device.name}</span>
+                {#if value}<span class="value">{value}</span>{/if}
+              </button>
+            {/each}
+          {/if}
+        </div>
+      {/if}
+    </section>
+  {/each}
+</div>
+
+<style>
+  .accordion {
+    display: flex;
+    flex-direction: column;
+    background: white;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow:
+      0 1px 2px rgba(16, 24, 40, 0.04),
+      0 1px 3px rgba(16, 24, 40, 0.06);
+    height: 100%;
+  }
+
+  .section {
+    border-top: 1px solid #f1f3f5;
+  }
+
+  .section.first {
+    border-top: none;
+  }
+
+  .head {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    width: 100%;
+    padding: 0.875rem 1rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: #667085;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    text-align: left;
+    transition: color 0.15s;
+  }
+
+  .head:hover {
+    color: #101828;
+  }
+
+  .section.open .head {
+    color: #101828;
+  }
+
+  .icon {
+    color: #98a2b3;
+    flex-shrink: 0;
+    transition: color 0.15s;
+  }
+
+  .section.open .icon {
+    color: #3b82f6;
+  }
+
+  .title {
+    flex: 1;
+  }
+
+  .badge {
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 0.375rem;
+    border-radius: 999px;
+    background: #eff6ff;
+    color: #1d4ed8;
+    font-size: 0.75rem;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .chevron {
+    color: #98a2b3;
+    transition: transform 0.18s ease;
+  }
+
+  .section.open .chevron {
+    transform: rotate(180deg);
+  }
+
+  .body {
+    padding: 0 0.5rem 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .empty {
+    color: #98a2b3;
+    font-size: 0.8125rem;
+    padding: 0.25rem 0.5rem 0.5rem;
+    margin: 0;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.5rem 0.625rem;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+    transition: background 0.12s;
+  }
+
+  .row:hover {
+    background: #f7f8fa;
+  }
+
+  .row.selected {
+    background: #f2f7ff;
+  }
+
+  .dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 5px;
+    border: 2px solid #d0d5dd;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    transition: all 0.12s;
+  }
+
+  .name {
+    flex: 1;
+    font-size: 0.875rem;
+    color: #475467;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .row.selected .name {
+    color: #101828;
+    font-weight: 500;
+  }
+
+  .value {
+    font-size: 0.8125rem;
+    color: #98a2b3;
+    font-variant-numeric: tabular-nums;
+  }
+
+  @media (max-width: 768px) {
+    .accordion {
+      height: auto;
+    }
+  }
+</style>

--- a/frontend/src/lib/explorer/MultiMetricChart.svelte
+++ b/frontend/src/lib/explorer/MultiMetricChart.svelte
@@ -1,0 +1,464 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import {
+    Chart,
+    LineController,
+    LineElement,
+    PointElement,
+    LinearScale,
+    TimeScale,
+    Tooltip,
+    Legend,
+    Filler,
+    type Plugin as ChartPlugin,
+  } from "chart.js";
+  import zoomPlugin from "chartjs-plugin-zoom";
+  import "chartjs-adapter-date-fns";
+  import { sensorsMemory } from "../memory";
+  import { coversRange } from "../memory/rangeSet";
+  import { TIME_RANGE_HOURS } from "../stores/graphConfig";
+  import { chartTimeFormats, formatDateTime, hourCycle } from "../utils/time";
+  import type { SensorReading } from "../api";
+  import type { ExplorerSeries } from "./explorerStore";
+  import { CATEGORY_BY_ID, metricValue } from "./metrics";
+
+  Chart.register(
+    LineController,
+    LineElement,
+    PointElement,
+    LinearScale,
+    TimeScale,
+    Tooltip,
+    Legend,
+    Filler,
+    zoomPlugin,
+  );
+
+  let {
+    series = [],
+    timeRange = "24h",
+  }: {
+    series?: ExplorerSeries[];
+    timeRange?: string;
+  } = $props();
+
+  const TARGET_POINTS = 1500;
+  const MIN_BUCKET_SECONDS = 1;
+  const inflightRequests = new Set<string>();
+
+  let canvas = $state<HTMLCanvasElement>();
+  let chart = $state<Chart | null>(null);
+  let zoomRange = $state<{ startSec: number; endSec: number } | null>(null);
+
+  // ---- presence bands overlay: full-height translucent bands drawn behind
+  // the lines. This is the first "overlay" layer — event/note markers will
+  // hook into the same plugin later (see chart.$overlays).
+  interface Band {
+    startMs: number;
+    endMs: number;
+    color: string;
+  }
+  const overlayPlugin: ChartPlugin = {
+    id: "explorerOverlays",
+    beforeDatasetsDraw(c) {
+      const bands: Band[] = (c as any).$bands ?? [];
+      if (bands.length === 0) return;
+      const { ctx, chartArea, scales } = c;
+      const x = scales.x;
+      if (!x) return;
+      ctx.save();
+      for (const band of bands) {
+        const left = x.getPixelForValue(band.startMs);
+        const right = x.getPixelForValue(band.endMs);
+        const clampedLeft = Math.max(chartArea.left, Math.min(chartArea.right, left));
+        const clampedRight = Math.max(chartArea.left, Math.min(chartArea.right, right));
+        const width = Math.max(1, clampedRight - clampedLeft);
+        ctx.fillStyle = band.color;
+        ctx.fillRect(clampedLeft, chartArea.top, width, chartArea.bottom - chartArea.top);
+      }
+      ctx.restore();
+    },
+  };
+  Chart.register(overlayPlugin);
+
+  let deviceMap = $derived(
+    new Map($sensorsMemory.devices.map((d) => [d.device_id, d])),
+  );
+  let seriesByDevice = $derived($sensorsMemory.seriesByDevice);
+
+  const lineSeries = $derived(series.filter((s) => CATEGORY_BY_ID[s.metric].kind === "line"));
+  const presenceSeries = $derived(series.filter((s) => CATEGORY_BY_ID[s.metric].kind === "band"));
+
+  // Distinct units among line series, in first-seen order → axis assignment.
+  const units = $derived.by(() => {
+    const seen: string[] = [];
+    for (const s of lineSeries) {
+      const unit = CATEGORY_BY_ID[s.metric].unit ?? "";
+      if (unit && !seen.includes(unit)) seen.push(unit);
+    }
+    return seen;
+  });
+  function axisIdForUnit(unit: string): string {
+    const idx = units.indexOf(unit);
+    return idx <= 0 ? "y" : `y${idx}`;
+  }
+
+  function getDefaultRangeSeconds(range: string) {
+    const hours = TIME_RANGE_HOURS[range as keyof typeof TIME_RANGE_HOURS] ?? 24;
+    const endSec = Math.floor(Date.now() / 1000);
+    return { startSec: endSec - hours * 3600, endSec };
+  }
+  function computeBucketSeconds(rangeSeconds: number) {
+    return Math.max(MIN_BUCKET_SECONDS, Math.ceil(rangeSeconds / TARGET_POINTS));
+  }
+
+  const activeRange = $derived(zoomRange ?? getDefaultRangeSeconds(timeRange));
+  const activeBucketSeconds = $derived(
+    computeBucketSeconds(activeRange.endSec - activeRange.startSec),
+  );
+
+  function hasCoverage(deviceId: string, bucket: number, startSec: number, endSec: number) {
+    const s = seriesByDevice[deviceId]?.[bucket];
+    return s ? coversRange(s.ranges, startSec, endSec) : false;
+  }
+  function getCachedReadings(deviceId: string, bucket: number, startSec: number, endSec: number) {
+    const s = seriesByDevice[deviceId]?.[bucket];
+    if (!s) return [] as SensorReading[];
+    const startMs = startSec * 1000;
+    const endMs = endSec * 1000;
+    return s.readings
+      .filter((r) => {
+        const ts = r.timestamp.getTime();
+        return ts >= startMs && ts <= endMs;
+      })
+      .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }
+
+  // Fetch any missing series data for the active range.
+  $effect(() => {
+    if (series.length === 0) return;
+    const { startSec, endSec } = activeRange;
+    const bucket = activeBucketSeconds;
+    for (const s of series) {
+      if (!hasCoverage(s.deviceId, bucket, startSec, endSec)) {
+        void requestSeries(s.deviceId, startSec, endSec, bucket);
+      }
+    }
+  });
+
+  async function requestSeries(deviceId: string, startSec: number, endSec: number, bucket: number) {
+    const key = `${deviceId}:${bucket}:${startSec}:${endSec}`;
+    if (inflightRequests.has(key)) return;
+    inflightRequests.add(key);
+    try {
+      await sensorsMemory.ensureAggregatedSeries(deviceId, startSec, endSec, bucket);
+    } catch (e) {
+      console.error("Failed to fetch aggregated readings:", e);
+    } finally {
+      inflightRequests.delete(key);
+    }
+  }
+
+  function buildDatasets() {
+    const datasets: any[] = [];
+    for (const s of lineSeries) {
+      const cat = CATEGORY_BY_ID[s.metric];
+      const readings = getCachedReadings(
+        s.deviceId,
+        activeBucketSeconds,
+        activeRange.startSec,
+        activeRange.endSec,
+      );
+      const points = readings
+        .map((r) => ({ x: r.timestamp.getTime(), v: metricValue(r, s.metric) }))
+        .filter((p) => p.v !== null)
+        .map((p) => ({ x: p.x, y: p.v as number }));
+      if (points.length === 0) continue;
+
+      const name = deviceMap.get(s.deviceId)?.name ?? s.deviceId;
+      datasets.push({
+        label: `${name} · ${cat.label}`,
+        data: points,
+        borderColor: s.color,
+        backgroundColor: `${s.color}20`,
+        yAxisID: axisIdForUnit(cat.unit ?? ""),
+        tension: 0.35,
+        pointRadius: 0.3,
+        pointHoverRadius: 3,
+        fill: false,
+        // dashed line for humidity so it reads apart from temperature of the
+        // same device / color
+        borderDash: s.metric === "humidity" ? [5, 4] : [],
+        unit: cat.unit,
+      });
+    }
+    return datasets;
+  }
+
+  function buildBands(): Band[] {
+    const bands: Band[] = [];
+    const bucketMs = activeBucketSeconds * 1000;
+    for (const s of presenceSeries) {
+      const readings = getCachedReadings(
+        s.deviceId,
+        activeBucketSeconds,
+        activeRange.startSec,
+        activeRange.endSec,
+      );
+      const fill = `${s.color}2e`; // ~18% alpha "sun" band
+      let open: Band | null = null;
+      for (const r of readings) {
+        const occupied = metricValue(r, "presence") === 1;
+        const t = r.timestamp.getTime();
+        if (occupied) {
+          if (open && t - open.endMs <= bucketMs * 2) {
+            open.endMs = t;
+          } else {
+            if (open) bands.push(open);
+            open = { startMs: t - bucketMs / 2, endMs: t, color: fill };
+          }
+        } else if (open) {
+          open.endMs = Math.max(open.endMs, open.startMs) + bucketMs / 2;
+          bands.push(open);
+          open = null;
+        }
+      }
+      if (open) {
+        open.endMs += bucketMs / 2;
+        bands.push(open);
+      }
+    }
+    return bands;
+  }
+
+  function buildScales() {
+    const scales: any = {
+      x: {
+        type: "time",
+        time: {
+          tooltipFormat: "PPpp",
+          displayFormats: chartTimeFormats(timeRange),
+        },
+        grid: { display: false },
+        ticks: { maxRotation: 0, font: { size: 11 } },
+      },
+    };
+    units.forEach((unit, idx) => {
+      const axisId = idx === 0 ? "y" : `y${idx}`;
+      const isTemp = unit === "°C";
+      scales[axisId] = {
+        type: "linear",
+        position: idx === 0 ? "left" : "right",
+        title: { display: true, text: unit, font: { size: 12 } },
+        grid: {
+          drawOnChartArea: idx === 0,
+          color: (ctx: any) =>
+            ctx.tick?.value === 0 && isTemp
+              ? "rgba(107, 114, 128, 0.9)"
+              : "rgba(0, 0, 0, 0.05)",
+          lineWidth: (ctx: any) => (ctx.tick?.value === 0 && isTemp ? 2 : 1),
+        },
+        ticks: { font: { size: 11 } },
+        ...(unit === "%" ? { min: 0, max: 100 } : {}),
+      };
+    });
+    return scales;
+  }
+
+  function updateZoomRangeFromChart(sourceChart: Chart) {
+    const xScale = sourceChart.scales?.x as any;
+    if (!xScale) return;
+    const { min, max } = xScale;
+    if (typeof min !== "number" || typeof max !== "number") return;
+    zoomRange = { startSec: Math.floor(min / 1000), endSec: Math.floor(max / 1000) };
+  }
+  function resetZoom() {
+    chart?.resetZoom();
+    zoomRange = null;
+  }
+  function handleContextMenu(event: MouseEvent) {
+    event.preventDefault();
+    resetZoom();
+  }
+
+  function createChart() {
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    chart = new Chart(ctx, {
+      type: "line",
+      data: { datasets: buildDatasets() },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: "nearest", intersect: false, axis: "x" },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            enabled: true,
+            callbacks: {
+              title: (items) =>
+                items.length && items[0].parsed.x !== null
+                  ? formatDateTime(new Date(items[0].parsed.x))
+                  : "",
+              label: (item) => {
+                const unit = (item.dataset as any).unit ?? "";
+                const y = item.parsed.y;
+                return `${item.dataset.label}: ${y}${unit ? ` ${unit}` : ""}`;
+              },
+            },
+          },
+          zoom: {
+            pan: {
+              enabled: true,
+              mode: "x",
+              modifierKey: "shift",
+              onPanComplete: ({ chart }) => updateZoomRangeFromChart(chart),
+            },
+            zoom: {
+              drag: { enabled: true },
+              mode: "x",
+              onZoomComplete: ({ chart }) => updateZoomRangeFromChart(chart),
+            },
+            limits: { x: { min: "original", max: "original" } },
+          },
+        },
+        scales: buildScales(),
+      },
+    });
+    (chart as any).$bands = buildBands();
+  }
+
+  function updateChart() {
+    if (!chart) return;
+    chart.data.datasets = buildDatasets();
+    chart.options.scales = buildScales() as any;
+    const xAxis = chart.options.scales?.x as any;
+    if (xAxis?.time) xAxis.time.displayFormats = chartTimeFormats(timeRange);
+    (chart as any).$bands = buildBands();
+    chart.update("none");
+  }
+
+  // Structural signature — when it changes we rebuild the chart (scales differ);
+  // otherwise we update data in place.
+  const structureSig = $derived(
+    JSON.stringify({
+      s: series.map((s) => `${s.deviceId}:${s.metric}:${s.color}`),
+      u: units,
+    }),
+  );
+  let prevSig: string | undefined = $state(undefined);
+
+  let previousTimeRange: string | undefined = $state(undefined);
+  $effect(() => {
+    if (previousTimeRange !== undefined && timeRange !== previousTimeRange) {
+      zoomRange = null;
+    }
+    previousTimeRange = timeRange;
+  });
+
+  $effect(() => {
+    if (series.length === 0) {
+      if (chart) {
+        chart.destroy();
+        chart = null;
+      }
+      prevSig = undefined;
+      return;
+    }
+    if (!canvas) return;
+
+    if (!chart || structureSig !== prevSig) {
+      if (chart) {
+        chart.destroy();
+        chart = null;
+      }
+      createChart();
+      prevSig = structureSig;
+    } else {
+      // touch reactive deps so data updates re-run this effect
+      void activeRange;
+      void seriesByDevice;
+      updateChart();
+    }
+  });
+
+  // Refresh axis time labels when the clock preference changes.
+  $effect(() => {
+    void $hourCycle;
+    if (chart) {
+      const xAxis = chart.options.scales?.x as any;
+      if (xAxis?.time) {
+        xAxis.time.displayFormats = chartTimeFormats(timeRange);
+        chart.update("none");
+      }
+    }
+  });
+
+  onDestroy(() => {
+    if (chart) {
+      chart.destroy();
+      chart = null;
+    }
+  });
+
+  const anyData = $derived(
+    lineSeries.some(
+      (s) =>
+        getCachedReadings(s.deviceId, activeBucketSeconds, activeRange.startSec, activeRange.endSec)
+          .length > 0,
+    ) ||
+      presenceSeries.some(
+        (s) =>
+          getCachedReadings(s.deviceId, activeBucketSeconds, activeRange.startSec, activeRange.endSec)
+            .length > 0,
+      ),
+  );
+</script>
+
+<div class="chart-container">
+  {#if series.length === 0}
+    <div class="no-data">
+      <p>Aucune série sélectionnée. Choisissez des capteurs dans le panneau de gauche.</p>
+    </div>
+  {:else}
+    <canvas bind:this={canvas} oncontextmenu={handleContextMenu}></canvas>
+    {#if !anyData}
+      <div class="no-data overlay">
+        <p>Chargement des données…</p>
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .chart-container {
+    width: 100%;
+    height: 100%;
+    min-height: 320px;
+    position: relative;
+    background: transparent;
+  }
+
+  canvas {
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  .no-data {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #6b7280;
+    font-size: 0.9375rem;
+    text-align: center;
+    padding: 1rem;
+  }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.9);
+  }
+</style>

--- a/frontend/src/lib/explorer/SelectedSeriesBar.svelte
+++ b/frontend/src/lib/explorer/SelectedSeriesBar.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { sensorsMemory } from "../memory";
+  import { explorerConfig, type ExplorerSeries } from "./explorerStore";
+  import { CATEGORY_BY_ID } from "./metrics";
+
+  let { series = [] }: { series?: ExplorerSeries[] } = $props();
+
+  const deviceMap = $derived(new Map($sensorsMemory.devices.map((d) => [d.device_id, d])));
+
+  function name(deviceId: string) {
+    return deviceMap.get(deviceId)?.name ?? deviceId;
+  }
+</script>
+
+{#if series.length > 0}
+  <div class="chips">
+    {#each series as s (s.deviceId + ":" + s.metric)}
+      {@const cat = CATEGORY_BY_ID[s.metric]}
+      <span class="chip">
+        <label class="swatch" style={`background:${s.color}`} title="Changer la couleur">
+          <input
+            type="color"
+            value={s.color}
+            oninput={(e) => explorerConfig.setColor(s.deviceId, s.metric, e.currentTarget.value)}
+          />
+        </label>
+        <span class="text">{name(s.deviceId)} · {cat.label}{cat.unit ? ` (${cat.unit})` : ""}</span>
+        <button
+          class="remove"
+          aria-label={`Retirer ${name(s.deviceId)} ${cat.label}`}
+          onclick={() => explorerConfig.removeSeries(s.deviceId, s.metric)}
+        >
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </span>
+    {/each}
+
+    <button class="clear" onclick={() => explorerConfig.clear()}>Tout effacer</button>
+  </div>
+{/if}
+
+<style>
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.3rem 0.35rem 0.3rem 0.4rem;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 999px;
+    font-size: 0.8125rem;
+    color: #374151;
+  }
+
+  .swatch {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    flex-shrink: 0;
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+  }
+
+  .swatch input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+    border: none;
+    padding: 0;
+  }
+
+  .text {
+    white-space: nowrap;
+  }
+
+  .remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: #9ca3af;
+    cursor: pointer;
+  }
+
+  .remove:hover {
+    background: #f3f4f6;
+    color: #ef4444;
+  }
+
+  .clear {
+    background: transparent;
+    border: none;
+    color: #6b7280;
+    font-size: 0.8125rem;
+    cursor: pointer;
+    padding: 0.3rem 0.5rem;
+    border-radius: 6px;
+  }
+
+  .clear:hover {
+    background: #f3f4f6;
+    color: #111827;
+  }
+</style>

--- a/frontend/src/lib/explorer/SensorExplorer.svelte
+++ b/frontend/src/lib/explorer/SensorExplorer.svelte
@@ -1,0 +1,171 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import CategoryRail from "./CategoryRail.svelte";
+  import SelectedSeriesBar from "./SelectedSeriesBar.svelte";
+  import MultiMetricChart from "./MultiMetricChart.svelte";
+  import { explorerConfig, type ExplorerTimeRange } from "./explorerStore";
+  import { sensorsMemory } from "../memory";
+  import { hourCycle, useHour12 } from "../utils/time";
+
+  const series = $derived($explorerConfig.series);
+  const timeRange = $derived($explorerConfig.timeRange);
+  const clock12 = $derived(
+    $hourCycle === "24h" ? false : $hourCycle === "12h" ? true : useHour12(),
+  );
+
+  const RANGES: { id: ExplorerTimeRange; label: string }[] = [
+    { id: "24h", label: "24h" },
+    { id: "1w", label: "1s" },
+    { id: "1m", label: "1m" },
+    { id: "1y", label: "1a" },
+  ];
+
+  onMount(() => {
+    // Populate "latest value" labels for every sensor in the rail.
+    void sensorsMemory.refreshLatestReadings().catch((e) => console.error(e));
+  });
+</script>
+
+<div class="board">
+  <aside class="rail">
+    <CategoryRail />
+  </aside>
+
+  <section class="graph-card">
+    <header class="graph-toolbar">
+      <div class="segmented">
+        {#each RANGES as r (r.id)}
+          <button
+            class="seg"
+            class:active={timeRange === r.id}
+            onclick={() => explorerConfig.setTimeRange(r.id)}
+          >
+            {r.label}
+          </button>
+        {/each}
+      </div>
+
+      <div class="segmented">
+        <button class="seg" class:active={!clock12} onclick={() => hourCycle.set("24h")}>24h</button>
+        <button class="seg" class:active={clock12} onclick={() => hourCycle.set("12h")}>12h</button>
+      </div>
+
+      <span class="hint">Glisser pour zoomer · Maj+glisser pour naviguer · clic droit pour réinitialiser</span>
+    </header>
+
+    {#if series.length > 0}
+      <div class="chips">
+        <SelectedSeriesBar {series} />
+      </div>
+    {/if}
+
+    <div class="chart">
+      <MultiMetricChart {series} {timeRange} />
+    </div>
+  </section>
+</div>
+
+<style>
+  /* The gray "board" ties the accordion and the graph into one integrated
+     surface; both sit on it as white panels with a tight gutter. */
+  .board {
+    display: grid;
+    grid-template-columns: minmax(240px, 288px) 1fr;
+    gap: 10px;
+    padding: 1.25rem;
+    background: #eef1f5;
+    border-radius: 18px;
+    margin: 1.25rem;
+    align-items: stretch;
+    min-height: calc(100vh - var(--app-header-height, 88px) - 2.5rem);
+  }
+
+  .rail {
+    min-height: 0;
+  }
+
+  .graph-card {
+    display: flex;
+    flex-direction: column;
+    background: white;
+    border-radius: 12px;
+    box-shadow:
+      0 1px 2px rgba(16, 24, 40, 0.04),
+      0 1px 3px rgba(16, 24, 40, 0.06);
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .graph-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid #f1f3f5;
+    flex-wrap: wrap;
+  }
+
+  .segmented {
+    display: inline-flex;
+    background: #f2f4f7;
+    border-radius: 8px;
+    padding: 3px;
+    gap: 2px;
+  }
+
+  .seg {
+    padding: 0.3rem 0.7rem;
+    border: none;
+    background: transparent;
+    border-radius: 6px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: #667085;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .seg:hover {
+    color: #101828;
+  }
+
+  .seg.active {
+    background: white;
+    color: #101828;
+    box-shadow: 0 1px 2px rgba(16, 24, 40, 0.12);
+  }
+
+  .hint {
+    margin-left: auto;
+    font-size: 0.75rem;
+    color: #b0b7c3;
+  }
+
+  .chips {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid #f1f3f5;
+  }
+
+  .chart {
+    flex: 1;
+    min-height: 0;
+    padding: 0.75rem;
+  }
+
+  @media (max-width: 768px) {
+    .board {
+      grid-template-columns: 1fr;
+      padding: 0.75rem;
+      margin: 0.75rem;
+      gap: 0.75rem;
+    }
+
+    .hint {
+      display: none;
+    }
+
+    .chart {
+      height: clamp(300px, 50vh, 560px);
+    }
+  }
+</style>

--- a/frontend/src/lib/explorer/explorerStore.ts
+++ b/frontend/src/lib/explorer/explorerStore.ts
@@ -1,0 +1,142 @@
+import { writable } from 'svelte/store';
+import { RECOMMENDED_COLORS, type GraphState } from '../stores/graphConfig';
+import { seriesKey, type ExplorerMetric } from './metrics';
+
+export type ExplorerTimeRange = GraphState['timeRange'];
+
+export interface ExplorerSeries {
+  deviceId: string;
+  metric: ExplorerMetric;
+  color: string;
+}
+
+export interface ExplorerState {
+  /** selected series, in insertion order (drives dataset + legend order) */
+  series: ExplorerSeries[];
+  timeRange: ExplorerTimeRange;
+  /**
+   * Reserved for a future "normalize to 0–100%" toggle when many units are on
+   * screen. Not surfaced in the UI yet — see docs / issue backlog.
+   */
+  normalize: boolean;
+}
+
+const STORAGE_KEY = 'homeAutomation:explorerConfig';
+
+const initialState: ExplorerState = {
+  series: [],
+  timeRange: '24h',
+  normalize: false,
+};
+
+function loadPersisted(): Partial<ExplorerState> {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    return {
+      series: Array.isArray(parsed.series) ? parsed.series : [],
+      timeRange: parsed.timeRange ?? '24h',
+      normalize: !!parsed.normalize,
+    };
+  } catch (e) {
+    console.warn('Failed to load explorer config:', e);
+    return {};
+  }
+}
+
+function createExplorerConfig() {
+  const { subscribe, update } = writable<ExplorerState>({
+    ...initialState,
+    ...loadPersisted(),
+  });
+
+  let saveTimeout: ReturnType<typeof setTimeout>;
+  function persist(state: ExplorerState) {
+    clearTimeout(saveTimeout);
+    saveTimeout = setTimeout(() => {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+      } catch (e) {
+        console.warn('Failed to persist explorer config:', e);
+      }
+    }, 400);
+  }
+
+  function nextColor(state: ExplorerState, preferred?: string | null): string {
+    if (preferred && preferred.trim()) return preferred;
+    const used = new Set(state.series.map((s) => s.color));
+    const free = RECOMMENDED_COLORS.find((c) => !used.has(c));
+    return free ?? RECOMMENDED_COLORS[state.series.length % RECOMMENDED_COLORS.length];
+  }
+
+  return {
+    subscribe,
+
+    /** Add or remove a (device, metric) series. */
+    toggleSeries(deviceId: string, metric: ExplorerMetric, preferredColor?: string | null) {
+      update((state) => {
+        const key = seriesKey(deviceId, metric);
+        const exists = state.series.some((s) => seriesKey(s.deviceId, s.metric) === key);
+        const series = exists
+          ? state.series.filter((s) => seriesKey(s.deviceId, s.metric) !== key)
+          : [...state.series, { deviceId, metric, color: nextColor(state, preferredColor) }];
+        const next = { ...state, series };
+        persist(next);
+        return next;
+      });
+    },
+
+    removeSeries(deviceId: string, metric: ExplorerMetric) {
+      update((state) => {
+        const key = seriesKey(deviceId, metric);
+        const next = {
+          ...state,
+          series: state.series.filter((s) => seriesKey(s.deviceId, s.metric) !== key),
+        };
+        persist(next);
+        return next;
+      });
+    },
+
+    setColor(deviceId: string, metric: ExplorerMetric, color: string) {
+      update((state) => {
+        const key = seriesKey(deviceId, metric);
+        const next = {
+          ...state,
+          series: state.series.map((s) =>
+            seriesKey(s.deviceId, s.metric) === key ? { ...s, color } : s,
+          ),
+        };
+        persist(next);
+        return next;
+      });
+    },
+
+    clear() {
+      update((state) => {
+        const next = { ...state, series: [] };
+        persist(next);
+        return next;
+      });
+    },
+
+    setTimeRange(timeRange: ExplorerTimeRange) {
+      update((state) => {
+        const next = { ...state, timeRange };
+        persist(next);
+        return next;
+      });
+    },
+
+    setNormalize(normalize: boolean) {
+      update((state) => {
+        const next = { ...state, normalize };
+        persist(next);
+        return next;
+      });
+    },
+  };
+}
+
+export const explorerConfig = createExplorerConfig();

--- a/frontend/src/lib/explorer/metrics.ts
+++ b/frontend/src/lib/explorer/metrics.ts
@@ -1,0 +1,106 @@
+import type { DeviceInfo } from '../api/devices';
+import type { SensorReading } from '../api';
+import type { SensorType } from '../types/sensors';
+
+/**
+ * A "metric" is one plottable channel. A single temp/humidity device exposes
+ * two of them (temperature + humidity), which is why the explorer keys series
+ * by (deviceId, metric) rather than by device alone.
+ */
+export type ExplorerMetric = 'temperature' | 'humidity' | 'power' | 'presence';
+
+export type MetricKind = 'line' | 'band';
+
+export interface CategoryDef {
+  /** metric id, also used as the left-rail tab id */
+  id: ExplorerMetric;
+  label: string;
+  /** display unit; null for presence (no value axis — rendered as bands) */
+  unit: string | null;
+  sensorType: SensorType;
+  kind: MetricKind;
+  /** inline SVG path drawn in a 24x24 viewBox */
+  iconPath: string;
+}
+
+export const CATEGORIES: CategoryDef[] = [
+  {
+    id: 'temperature',
+    label: 'Température',
+    unit: '°C',
+    sensorType: 'temp_humidity',
+    kind: 'line',
+    iconPath:
+      'M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0zM12 3.5a.5.5 0 0 1 1 0V12h-1z',
+  },
+  {
+    id: 'humidity',
+    label: 'Humidité',
+    unit: '%',
+    sensorType: 'temp_humidity',
+    kind: 'line',
+    iconPath: 'M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z',
+  },
+  {
+    id: 'presence',
+    label: 'Présence',
+    unit: null,
+    sensorType: 'presence',
+    kind: 'band',
+    iconPath:
+      'M12 2a2 2 0 1 1 0 4 2 2 0 0 1 0-4zm-1.5 6h3l3 6-2 1-2-3v10h-2V13l-2 3-2-1z',
+  },
+  {
+    id: 'power',
+    label: 'Énergie',
+    unit: 'W',
+    sensorType: 'energy_meter',
+    kind: 'line',
+    iconPath: 'M13 2L3 14h7l-1 8 10-12h-7z',
+  },
+];
+
+export const CATEGORY_BY_ID: Record<ExplorerMetric, CategoryDef> = Object.fromEntries(
+  CATEGORIES.map((c) => [c.id, c]),
+) as Record<ExplorerMetric, CategoryDef>;
+
+export function seriesKey(deviceId: string, metric: ExplorerMetric): string {
+  return `${deviceId}:${metric}`;
+}
+
+/** Does this device expose the given metric? */
+export function deviceHasMetric(device: DeviceInfo, metric: ExplorerMetric): boolean {
+  const { sensorType } = CATEGORY_BY_ID[metric];
+  return device.capabilities.some(
+    (cap) => cap.type === 'sensor' && cap.sensor_type === sensorType,
+  );
+}
+
+/** Devices offering the metric of a given category. */
+export function devicesForCategory(devices: DeviceInfo[], metric: ExplorerMetric): DeviceInfo[] {
+  return devices.filter((d) => deviceHasMetric(d, metric));
+}
+
+/**
+ * Numeric value of a reading for a metric, or null if the reading isn't of the
+ * matching type. Presence returns 0/1 (used only for band detection).
+ */
+export function metricValue(reading: SensorReading, metric: ExplorerMetric): number | null {
+  switch (metric) {
+    case 'temperature':
+      return reading.type === 'temp_humidity' ? reading.temperature : null;
+    case 'humidity':
+      return reading.type === 'temp_humidity' ? reading.humidity : null;
+    case 'power':
+      return reading.type === 'energy_meter' ? reading.power : null;
+    case 'presence':
+      return reading.type === 'presence' ? (reading.occupied ? 1 : 0) : null;
+  }
+}
+
+export function formatMetricValue(value: number, metric: ExplorerMetric): string {
+  const unit = CATEGORY_BY_ID[metric].unit;
+  if (metric === 'presence') return value >= 0.5 ? 'Occupé' : 'Libre';
+  const digits = metric === 'power' ? 0 : 1;
+  return `${value.toFixed(digits)}${unit ? ` ${unit}` : ''}`;
+}

--- a/frontend/src/routes/SensorsView.svelte
+++ b/frontend/src/routes/SensorsView.svelte
@@ -1,66 +1,24 @@
 <script lang="ts">
-  import UnifiedGraphPanel from "../lib/graphs/UnifiedGraphPanel.svelte";
-  import SensorListPanel from "../lib/devices/SensorListPanel.svelte";
-  import PageState from "../lib/shared/PageState.svelte";
-  import type { DeviceInfo } from "../lib/api/devices";
-  import { deviceStateMemory, sensorsMemory } from "../lib/memory";
-  import { graphConfig } from "../lib/stores/graphConfig";
   import { onMount } from "svelte";
+  import SensorExplorer from "../lib/explorer/SensorExplorer.svelte";
+  import PageState from "../lib/shared/PageState.svelte";
+  import { sensorsMemory } from "../lib/memory";
 
   let loading = $state(true);
   let error = $state<string | null>(null);
-  let initialized = $state(false);
-
-  // Filter: exclude energy meters (they belong in ConsommationsView)
-  const isEnergyMeter = (device: DeviceInfo) =>
-    device.capabilities.some(
-      (cap) => cap.type === "sensor" && cap.sensor_type === "energy_meter"
-    );
-
-  // Filter: exclude binary on/off (presence) sensors from this page (#13)
-  const isBinarySensor = (device: DeviceInfo) =>
-    device.capabilities.some(
-      (cap) => cap.type === "sensor" && cap.sensor_type === "presence"
-    );
-
-  // Initialize graphConfig with the correct sensors for this view
-  function initializeGraphConfig(devices: DeviceInfo[]) {
-    const sensorDevices = devices
-      .filter((d) => !isEnergyMeter(d) && !isBinarySensor(d))
-      .map((s) => ({ deviceId: s.device_id, color: s.color }));
-    graphConfig.initializeSensors(sensorDevices);
-  }
 
   async function loadData(force = false) {
-    const sensorState = $sensorsMemory;
-
-    if (!force && sensorState.devicesLoaded) {
-      initializeGraphConfig(sensorState.devices);
-      if (!initialized) {
-        graphConfig.hideAll();
-        initialized = true;
-      }
+    const state = $sensorsMemory;
+    if (!force && state.devicesLoaded) {
       loading = false;
       return;
     }
-
     loading = true;
     error = null;
-
     try {
-      const sensors = await sensorsMemory.ensureDevices(force);
-
-      // Always initialize graphConfig for this view
-      initializeGraphConfig(sensors);
-      if (!initialized) {
-        graphConfig.hideAll();
-        initialized = true;
-      }
-      void deviceStateMemory.ensureDeviceStates(force).catch((err) => {
-        console.error("Failed to fetch device states:", err);
-      });
+      await sensorsMemory.ensureDevices(force);
     } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to load sensor data";
+      error = err instanceof Error ? err.message : "Échec du chargement des capteurs";
     } finally {
       loading = false;
     }
@@ -76,15 +34,8 @@
 </script>
 
 <div class="sensor-view">
-  <PageState {loading} {error} loadingText="Loading sensors..." onRetry={retryLoad}>
-    <div class="unified-layout">
-      <div class="graph-section">
-        <UnifiedGraphPanel />
-      </div>
-      <div class="sensors-section">
-        <SensorListPanel />
-      </div>
-    </div>
+  <PageState {loading} {error} loadingText="Chargement des capteurs…" onRetry={retryLoad}>
+    <SensorExplorer />
   </PageState>
 </div>
 
@@ -92,33 +43,5 @@
   .sensor-view {
     width: 100%;
     height: 100%;
-  }
-
-  .unified-layout {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    height: 100%;
-  }
-
-  .graph-section {
-    flex: 0 0 auto;
-  }
-
-  .sensors-section {
-    flex: 1;
-    min-height: 0;
-  }
-
-  @media (max-width: 768px) {
-    .unified-layout {
-      gap: var(--section-gap, 1.5rem);
-    }
-  }
-
-  @media (max-width: 480px) {
-    .unified-layout {
-      gap: var(--section-gap, 1rem);
-    }
   }
 </style>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,16 +1,23 @@
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import checker from 'vite-plugin-checker';
+import { mockBackend } from './mock/plugin';
+
+// Set VITE_MOCK=1 (see `npm run dev:mock`) to serve a fake backend locally
+// instead of proxying to the Rust server on :8080.
+const useMock = !!process.env.VITE_MOCK;
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [svelte(),
-  checker({
-    typescript: true,
-    overlay: {
-      initialIsOpen: false,
-    },
-  }),
+  plugins: [
+    svelte(),
+    checker({
+      typescript: true,
+      overlay: {
+        initialIsOpen: false,
+      },
+    }),
+    ...(useMock ? [mockBackend()] : []),
   ],
 
   build: {
@@ -32,16 +39,19 @@ export default defineConfig({
   },
 
   server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-      },
-      '/ws': {
-        target: 'ws://localhost:8080',
-        changeOrigin: true,
-        ws: true,
-      },
-    },
+    // In mock mode the plugin owns /api and /ws, so the proxy must stay off.
+    proxy: useMock
+      ? undefined
+      : {
+          '/api': {
+            target: 'http://localhost:8080',
+            changeOrigin: true,
+          },
+          '/ws': {
+            target: 'ws://localhost:8080',
+            changeOrigin: true,
+            ws: true,
+          },
+        },
   },
 })


### PR DESCRIPTION
## Résumé

Refonte de l'onglet **Sensors** en un explorateur unifié qui croise tous les types de capteurs sur un seul graphe, + un backend **mock** pour développer le front sans le backend Rust.

### Explorateur
- **Rail en accordéon** (plusieurs volets ouvrables simultanément) groupant les capteurs par **Température / Humidité / Présence / Énergie**, chaque ligne affichant sa valeur live ; cliquer ajoute une série `(device, metric)`.
- **Multi-unités** : chaque unité (°C, %, W) a son propre axe Y ; la **présence** (sans unité) est rendue en **bandes pleine hauteur couleur soleil** derrière les courbes via un plugin Chart.js d'overlay (extensible aux marqueurs d'événements/notes plus tard).
- **Look intégré** : accordéon + graphe en panneaux blancs sur un board gris, contrôles (période / horloge) intégrés dans l'en-tête de la carte graphe, barre de chips récapitulant les séries actives (couleur éditable, suppression).

### Mock local (`npm run dev:mock`, `VITE_MOCK=1`)
- Plugin de dev-server Vite servant toutes les routes `/api` avec des données générées **déterministes** + un WebSocket `/ws` poussant des lectures live.
- Faux **plan d'appartement** : SVG + topologie réseau en étoile + positions des appareils (drag persisté en session).
- **Zéro impact sur le bundle de prod** ; `npm run dev` continue d'utiliser le proxy réel vers `:8080`.

## Vérification
- `svelte-check` : 0 erreur / 0 warning
- `vite build` : OK
- Rendu validé en navigateur headless (explorateur + accordéon multi-ouverture + plan), **0 erreur console**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)