### PR TITLE
feat(energy): dashboard d'énergie cumulée + pages énergie en thème clair

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-demo
 dist-ssr
 *.local
 

--- a/frontend/mock/browser.ts
+++ b/frontend/mock/browser.ts
@@ -1,0 +1,155 @@
+/**
+ * In-browser mock backend for the static online demo.
+ *
+ * The Vite dev plugin (`mock/plugin.ts`) runs in Node and is NOT part of the
+ * production bundle, so a statically-hosted build (e.g. GitHub Pages) has
+ * nothing answering `/api/*` or `/ws`. This module fills that gap entirely
+ * client-side by patching `window.fetch` and `window.WebSocket`, delegating to
+ * the same shared core so the behaviour matches `npm run dev:mock`.
+ *
+ * It is imported dynamically from `main.ts` only when built with
+ * `VITE_MOCK_BUILD=1` (see `npm run build:demo`), so a normal production build
+ * that talks to the real Rust backend never pulls it in.
+ */
+import { handleRequest, nextSensorReading, onEvent } from './core';
+
+const API_PREFIX = '/api/';
+const WS_PATH = '/ws';
+
+function isApiPath(pathname: string): boolean {
+  return pathname.startsWith(API_PREFIX);
+}
+
+/** Patch fetch so `/api/*` requests are served from the core in-memory. */
+function installFetch() {
+  const realFetch = window.fetch.bind(window);
+
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const request = input instanceof Request ? input : null;
+    const rawUrl = request ? request.url : String(input);
+    const url = new URL(rawUrl, window.location.origin);
+
+    if (!isApiPath(url.pathname)) {
+      return realFetch(input as RequestInfo, init);
+    }
+
+    const method = (init?.method ?? request?.method ?? 'GET').toUpperCase();
+
+    let body: unknown = null;
+    const rawBody = init?.body ?? (request ? await request.clone().text() : null);
+    if (typeof rawBody === 'string' && rawBody.length > 0) {
+      try {
+        body = JSON.parse(rawBody);
+      } catch {
+        body = null;
+      }
+    }
+
+    const { status, body: out, headers } = handleRequest(method, url.pathname, url.searchParams, body);
+
+    return new Response(JSON.stringify(out), {
+      status,
+      headers: { 'Content-Type': 'application/json', ...(headers ?? {}) },
+    });
+  };
+}
+
+type Listener = (ev: Event) => void;
+
+/**
+ * Minimal WebSocket stand-in for the `/ws` event stream. Implements just enough
+ * of the WebSocket surface that EventStreamClient relies on (readyState, the
+ * static constants, onopen/onmessage/onclose, close()).
+ */
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSING = 2;
+  readonly CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  url: string;
+
+  onopen: Listener | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: Listener | null = null;
+  onclose: Listener | null = null;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    // Open on the next tick so the caller can attach handlers first.
+    setTimeout(() => this.open(), 0);
+  }
+
+  private open() {
+    if (this.readyState !== MockWebSocket.CONNECTING) return;
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+
+    // Relay events pushed by the core (switch_state after a command).
+    this.unsubscribe = onEvent((message) => this.deliver(message));
+
+    // Push a live sensor reading for a rotating device every few seconds.
+    this.timer = setInterval(() => this.deliver(nextSensorReading()), 3000);
+  }
+
+  private deliver(message: unknown) {
+    if (this.readyState !== MockWebSocket.OPEN) return;
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(message) }));
+  }
+
+  send() {
+    // The frontend never sends over this socket; nothing to do.
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+    if (this.timer) clearInterval(this.timer);
+    if (this.unsubscribe) this.unsubscribe();
+    this.timer = null;
+    this.unsubscribe = null;
+    this.onclose?.(new CloseEvent('close'));
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+}
+
+/** Patch WebSocket so `/ws` connections are served locally; others pass through. */
+function installWebSocket() {
+  const RealWebSocket = window.WebSocket;
+
+  const Patched = function (this: unknown, url: string | URL, protocols?: string | string[]) {
+    const target = new URL(String(url), window.location.origin);
+    if (target.pathname === WS_PATH) {
+      return new MockWebSocket(String(url)) as unknown as WebSocket;
+    }
+    return new RealWebSocket(url, protocols);
+  } as unknown as typeof WebSocket;
+
+  Patched.prototype = RealWebSocket.prototype;
+  Object.defineProperties(Patched, {
+    CONNECTING: { value: 0 },
+    OPEN: { value: 1 },
+    CLOSING: { value: 2 },
+    CLOSED: { value: 3 },
+  });
+
+  window.WebSocket = Patched;
+}
+
+/** Install the in-browser mock backend. Idempotent-ish; call once at startup. */
+export function installMockBackend() {
+  installFetch();
+  installWebSocket();
+  // eslint-disable-next-line no-console
+  console.log('🧪 Demo mode — /api and /ws are served in-browser (no backend).');
+}

--- a/frontend/mock/core.ts
+++ b/frontend/mock/core.ts
@@ -1,0 +1,306 @@
+/**
+ * Runtime-agnostic mock backend core.
+ *
+ * This holds ALL the fake-backend logic — request routing, in-memory switch
+ * state, and the outgoing WebSocket event stream — with zero dependency on
+ * Node's `http` types or the browser's `fetch`/`WebSocket`. Two thin adapters
+ * consume it:
+ *
+ *  - `mock/plugin.ts`  — Vite dev-server middleware + `ws` server (npm run dev:mock)
+ *  - `mock/browser.ts` — patches window.fetch / window.WebSocket for the static
+ *                        online demo (npm run build:demo)
+ *
+ * Keeping the logic here means the fixtures in `data.ts` and the behaviour of
+ * every route are a single source of truth across both runtimes.
+ */
+import {
+  MOCK_DEVICES,
+  MOCK_FLOOR_PLAN_SVG,
+  MOCK_SWITCHES,
+  deviceInfo,
+  findSwitch,
+  mockPositions,
+  mockTopology,
+  readingAt,
+  seriesFor,
+  type MockReading,
+} from './data';
+
+export interface MockResponse {
+  status: number;
+  body: unknown;
+  headers?: Record<string, string>;
+}
+
+const now = () => Math.floor(Date.now() / 1000);
+
+// --- session-scoped mutable state -------------------------------------------
+
+// Position overrides so dragging a device on the floor plan sticks for the
+// session.
+const positionOverrides: Record<string, { x: number; y: number }> = {};
+
+// Live on/off state per switch, seeded from the fixtures.
+const switchState: Record<string, boolean> = Object.fromEntries(
+  MOCK_SWITCHES.map((s) => [s.id, s.initial_state]),
+);
+
+// --- outgoing event bus (WebSocket messages) --------------------------------
+
+type Emitter = (message: unknown) => void;
+const emitters = new Set<Emitter>();
+
+/** Register a sink for pushed WS messages; returns an unsubscribe function. */
+export function onEvent(fn: Emitter): () => void {
+  emitters.add(fn);
+  return () => emitters.delete(fn);
+}
+
+function emit(message: unknown) {
+  for (const fn of emitters) fn(message);
+}
+
+// --- serializers -------------------------------------------------------------
+
+function deviceStatePayload(deviceId: string, seed: number) {
+  return {
+    device_id: deviceId,
+    battery_level: 60 + (seed % 40),
+    link_quality: 120 + (seed % 100),
+    last_seen: now() - (seed % 300),
+    turbo_mode: null,
+  };
+}
+
+/** SwitchDevice payload (matches frontend/src/lib/api/switches.ts). */
+function switchPayload(id: string) {
+  const s = findSwitch(id);
+  if (!s) return null;
+  return {
+    id: s.id,
+    name: s.name,
+    color: s.color,
+    state: switchState[s.id] ?? false,
+    link_quality: s.link_quality,
+    battery_level: s.battery_level,
+    last_seen: now() - (s._seed % 120),
+  };
+}
+
+// --- readings ----------------------------------------------------------------
+
+function handleReadings(query: URLSearchParams): MockResponse {
+  const deviceId = query.get('device_id') ?? undefined;
+  const targets = deviceId
+    ? MOCK_DEVICES.filter((d) => d.device_id === deviceId)
+    : MOCK_DEVICES;
+
+  // latest=1 → one most-recent reading per device.
+  if (query.get('latest') === '1' || query.get('latest')?.toLowerCase() === 'true') {
+    const t = now();
+    const readings = targets.map((d) => readingAt(d, t));
+    return { status: 200, body: readings, headers: { 'X-Latest-Timestamp': String(t) } };
+  }
+
+  const bucket = Math.max(1, parseInt(query.get('bucket') ?? '1', 10) || 1);
+  let start: number;
+  let end: number;
+  const startParam = query.get('start');
+  const endParam = query.get('end');
+  if (startParam && endParam) {
+    start = parseInt(startParam, 10);
+    end = parseInt(endParam, 10);
+  } else {
+    const hours = parseInt(query.get('hours') ?? '24', 10) || 24;
+    end = now();
+    start = end - hours * 3600;
+  }
+
+  const readings: MockReading[] = [];
+  for (const d of targets) {
+    readings.push(...seriesFor(d, start, end, bucket));
+  }
+  const latest = readings.reduce((max, r) => Math.max(max, r.timestamp), end);
+  return { status: 200, body: readings, headers: { 'X-Latest-Timestamp': String(latest) } };
+}
+
+// --- energy summary ----------------------------------------------------------
+
+const isEnergyMeter = (d: (typeof MOCK_DEVICES)[number]) =>
+  d.capabilities.some((c) => c.sensor_type === 'energy_meter');
+
+/**
+ * Mirror the Rust `/api/energy/summary`: bucket the cumulative counter and
+ * report per-bucket deltas (clamped ≥ 0 so the mock's periodic reset can't go
+ * negative), the totals, and peak power.
+ */
+function handleEnergySummary(query: URLSearchParams): MockResponse {
+  const deviceId = query.get('device_id') ?? undefined;
+  const bucket = Math.max(1, parseInt(query.get('bucket') ?? '86400', 10) || 86400);
+  const end = parseInt(query.get('end') ?? String(now()), 10);
+  const start = parseInt(query.get('start') ?? String(end - 86400), 10);
+
+  const meters = (
+    deviceId ? MOCK_DEVICES.filter((d) => d.device_id === deviceId) : MOCK_DEVICES
+  ).filter(isEnergyMeter);
+
+  const r3 = (x: number) => Math.round(x * 1000) / 1000;
+  const agg = new Map<number, { consumed: number; produced: number }>();
+  let peakPower = 0;
+  let peakTs: number | null = null;
+
+  for (const d of meters) {
+    const anchor = readingAt(d, start - 1);
+    let prevE = anchor.energy as number;
+    let prevP = anchor.produced_energy as number;
+    for (let b = start; b < end - 1; b += bucket) {
+      const sampleTs = Math.min(b + bucket - 1, end - 1);
+      const r = readingAt(d, sampleTs);
+      const e = r.energy as number;
+      const p = r.produced_energy as number;
+      const slot = agg.get(b) ?? { consumed: 0, produced: 0 };
+      slot.consumed += Math.max(0, e - prevE);
+      slot.produced += Math.max(0, p - prevP);
+      agg.set(b, slot);
+      prevE = e;
+      prevP = p;
+      const pw = r.power as number;
+      if (pw > peakPower) {
+        peakPower = pw;
+        peakTs = sampleTs;
+      }
+    }
+  }
+
+  const buckets = [...agg.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([timestamp, v]) => ({ timestamp, consumed: r3(v.consumed), produced: r3(v.produced) }));
+
+  return {
+    status: 200,
+    body: {
+      start,
+      end,
+      bucket_seconds: bucket,
+      total_consumed: r3(buckets.reduce((a, b) => a + b.consumed, 0)),
+      total_produced: r3(buckets.reduce((a, b) => a + b.produced, 0)),
+      peak_power: Math.round(peakPower * 10) / 10,
+      peak_power_timestamp: peakTs,
+      buckets,
+    },
+  };
+}
+
+// --- command execution -------------------------------------------------------
+
+/** Toggle a switch, then push a `switch_state` event so the UI reflects it. */
+function executeCommand(body: unknown): MockResponse {
+  const cmd = (body ?? {}) as { device_id?: string; state?: boolean | 'ON' | 'OFF' };
+  const id = cmd.device_id;
+  if (!id || !findSwitch(id)) {
+    return { status: 404, body: { error: `Unknown switch: ${id ?? '(none)'}` } };
+  }
+  const desired =
+    typeof cmd.state === 'string' ? cmd.state.toUpperCase() === 'ON' : Boolean(cmd.state);
+  switchState[id] = desired;
+
+  // Reflect the change on the event stream, like the real backend does after
+  // Zigbee confirms the state.
+  emit({ event: 'switch_state', device_id: id, state: desired, timestamp: now() });
+
+  return { status: 200, body: { ok: true } };
+}
+
+// --- request router ----------------------------------------------------------
+
+/**
+ * Handle one `/api/*` request. Pure w.r.t. I/O: takes the parsed method, path,
+ * query and (already-parsed) JSON body, returns status + body. Side effects are
+ * limited to session state and the event bus.
+ */
+export function handleRequest(
+  method: string,
+  path: string,
+  query: URLSearchParams,
+  body: unknown,
+): MockResponse {
+  const m = method.toUpperCase();
+
+  // --- reads used by the sensor explorer ---------------------------------
+  if (m === 'GET' && path === '/api/sensors') {
+    return { status: 200, body: MOCK_DEVICES.map(deviceInfo) };
+  }
+  if (m === 'GET' && path === '/api/energy/summary') {
+    return handleEnergySummary(query);
+  }
+  if (m === 'GET' && path === '/api/readings') {
+    return handleReadings(query);
+  }
+  if (m === 'GET' && path === '/api/devices/state') {
+    return { status: 200, body: MOCK_DEVICES.map((d) => deviceStatePayload(d.device_id, d._seed)) };
+  }
+
+  // --- floor plan tab ----------------------------------------------------
+  if (m === 'GET' && path === '/api/floor-plan') {
+    return { status: 200, body: { svg_content: MOCK_FLOOR_PLAN_SVG, uploaded_at: now() } };
+  }
+  if (m === 'GET' && path === '/api/network/topology') {
+    return { status: 200, body: mockTopology() };
+  }
+  if (m === 'GET' && path === '/api/devices/positions') {
+    return { status: 200, body: mockPositions(positionOverrides) };
+  }
+  if (m === 'PUT' && /^\/api\/devices\/.+\/position$/.test(path)) {
+    const deviceId = path.slice('/api/devices/'.length, -'/position'.length);
+    const { x, y } = (body ?? {}) as { x?: number; y?: number };
+    if (typeof x === 'number' && typeof y === 'number') {
+      positionOverrides[deviceId] = { x, y };
+    }
+    return { status: 200, body: { ok: true } };
+  }
+
+  // --- commander tab: real switch list + state mutation ------------------
+  if (m === 'GET' && path === '/api/devices/switches') {
+    return { status: 200, body: MOCK_SWITCHES.map((s) => switchPayload(s.id)) };
+  }
+  if (m === 'POST' && path === '/api/commands/execute') {
+    return executeCommand(body);
+  }
+
+  // --- other tabs: minimal but non-breaking answers ----------------------
+  if (m === 'GET' && path === '/api/automation/rules') return { status: 200, body: [] };
+  if (m === 'GET' && path === '/api/automation/logs') return { status: 200, body: [] };
+  if (m === 'GET' && path === '/api/system/storage') return { status: 200, body: {} };
+  if (m === 'GET' && path.startsWith('/api/logs/')) return { status: 200, body: [] };
+
+  // --- writes: accept and echo success -----------------------------------
+  if (m === 'POST' && path === '/api/zigbee/permit_join') return { status: 200, body: { ok: true } };
+  if (m === 'POST' && path === '/api/network/refresh') return { status: 200, body: { ok: true } };
+  if (m === 'DELETE' && path === '/api/floor-plan') return { status: 200, body: { ok: true } };
+  if (m === 'PATCH' && path.startsWith('/api/devices/')) return { status: 200, body: { ok: true } };
+  if (m === 'PUT' && path.startsWith('/api/devices/')) return { status: 200, body: { ok: true } };
+
+  // Anything else under /api: safe empty payload so the UI never hard-fails.
+  return { status: 200, body: [] };
+}
+
+// --- pushed sensor readings --------------------------------------------------
+
+let tickIndex = 0;
+
+/**
+ * Build the next live `sensor_reading` message for a rotating device. Callers
+ * own the interval (dev server ties it to the http server lifecycle, browser
+ * ties it to the socket), so the core stays timer-free.
+ */
+export function nextSensorReading() {
+  const dev = MOCK_DEVICES[tickIndex % MOCK_DEVICES.length];
+  tickIndex += 1;
+  const t = now();
+  return {
+    event: 'sensor_reading',
+    device_id: dev.device_id,
+    reading: readingAt(dev, t),
+    timestamp: t,
+  };
+}

--- a/frontend/mock/data.ts
+++ b/frontend/mock/data.ts
@@ -354,3 +354,65 @@ export function deviceInfo(dev: MockDevice) {
     color: dev.color,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Switches: commandable on/off devices for the Commander tab. Unlike sensors,
+// these carry mutable state (see mock/core.ts), so the demo can actually turn
+// them on and off with live feedback over the WebSocket.
+// ---------------------------------------------------------------------------
+
+export interface MockSwitch {
+  id: string;
+  name: string;
+  color: string | null;
+  /** Mains-powered switches report link quality but no battery. */
+  link_quality: number;
+  battery_level: number | null;
+  /** Initial on/off state at startup. */
+  initial_state: boolean;
+  _seed: number;
+}
+
+/** Catalogue of fake switches, one per room, mirroring the sensor rooms. */
+export const MOCK_SWITCHES: MockSwitch[] = [
+  {
+    id: '0xmock000000000s1',
+    name: 'Lampe salon',
+    color: '#f59e0b',
+    link_quality: 186,
+    battery_level: null,
+    initial_state: true,
+    _seed: 101,
+  },
+  {
+    id: '0xmock000000000s2',
+    name: 'Lampe chambre',
+    color: '#8b5cf6',
+    link_quality: 152,
+    battery_level: null,
+    initial_state: false,
+    _seed: 102,
+  },
+  {
+    id: '0xmock000000000s3',
+    name: 'Prise cuisine',
+    color: '#10b981',
+    link_quality: 204,
+    battery_level: null,
+    initial_state: false,
+    _seed: 103,
+  },
+  {
+    id: '0xmock000000000s4',
+    name: 'Guirlande terrasse',
+    color: '#ec4899',
+    link_quality: 118,
+    battery_level: null,
+    initial_state: true,
+    _seed: 104,
+  },
+];
+
+export function findSwitch(id: string): MockSwitch | undefined {
+  return MOCK_SWITCHES.find((s) => s.id === id);
+}

--- a/frontend/mock/plugin.ts
+++ b/frontend/mock/plugin.ts
@@ -2,40 +2,20 @@
  * Vite dev-server plugin that fakes the Rust backend so the frontend can run
  * fully standalone. Enabled only when VITE_MOCK is set (see `npm run dev:mock`).
  *
- *  - Intercepts every `/api/*` request and answers with generated JSON.
- *  - Runs a WebSocket server on `/ws` that pushes live sensor readings, so the
- *    "latest value" chips and sync indicator behave like production.
+ *  - Intercepts every `/api/*` request and answers via the shared mock core.
+ *  - Runs a WebSocket server on `/ws` that pushes live sensor readings and
+ *    switch-state changes, so the "latest value" chips, sync indicator and
+ *    Commander tab behave like production.
  *
- * It touches nothing in the production bundle: this file is only imported by
- * vite.config.ts and only wired in when the env flag is on.
+ * All the actual behaviour lives in `mock/core.ts` (shared with the in-browser
+ * demo shim). This file is just the Node/Vite adapter and is only imported by
+ * vite.config.ts, wired in when the env flag is on — it never touches the
+ * production bundle.
  */
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Plugin, ViteDevServer } from 'vite';
 import { WebSocketServer, type WebSocket } from 'ws';
-import {
-  MOCK_DEVICES,
-  MOCK_FLOOR_PLAN_SVG,
-  deviceInfo,
-  mockPositions,
-  mockTopology,
-  readingAt,
-  seriesFor,
-  type MockReading,
-} from './data';
-
-// Session-scoped position overrides so dragging a device on the floor plan
-// sticks until the dev server restarts.
-const positionOverrides: Record<string, { x: number; y: number }> = {};
-
-const now = () => Math.floor(Date.now() / 1000);
-
-function json(res: ServerResponse, body: unknown, extraHeaders: Record<string, string> = {}) {
-  const payload = JSON.stringify(body);
-  res.statusCode = 200;
-  res.setHeader('Content-Type', 'application/json');
-  for (const [k, v] of Object.entries(extraHeaders)) res.setHeader(k, v);
-  res.end(payload);
-}
+import { handleRequest, nextSensorReading, onEvent } from './core';
 
 function readBody(req: IncomingMessage, cb: (body: unknown) => void) {
   let raw = '';
@@ -49,108 +29,25 @@ function readBody(req: IncomingMessage, cb: (body: unknown) => void) {
   });
 }
 
-function deviceState(deviceId: string, seed: number) {
-  return {
-    device_id: deviceId,
-    battery_level: 60 + (seed % 40),
-    link_quality: 120 + (seed % 100),
-    last_seen: now() - (seed % 300),
-    turbo_mode: null,
-  };
-}
-
-function handleReadings(url: URL, res: ServerResponse) {
-  const q = url.searchParams;
-  const deviceId = q.get('device_id') ?? undefined;
-  const targets = deviceId ? MOCK_DEVICES.filter((d) => d.device_id === deviceId) : MOCK_DEVICES;
-
-  // latest=1 → one most-recent reading per device.
-  if (q.get('latest') === '1' || q.get('latest')?.toLowerCase() === 'true') {
-    const t = now();
-    const readings = targets.map((d) => readingAt(d, t));
-    return json(res, readings, { 'X-Latest-Timestamp': String(t) });
-  }
-
-  const bucket = Math.max(1, parseInt(q.get('bucket') ?? '1', 10) || 1);
-  let start: number;
-  let end: number;
-  const startParam = q.get('start');
-  const endParam = q.get('end');
-  if (startParam && endParam) {
-    start = parseInt(startParam, 10);
-    end = parseInt(endParam, 10);
-  } else {
-    const hours = parseInt(q.get('hours') ?? '24', 10) || 24;
-    end = now();
-    start = end - hours * 3600;
-  }
-
-  const readings: MockReading[] = [];
-  for (const d of targets) {
-    readings.push(...seriesFor(d, start, end, bucket));
-  }
-  const latest = readings.reduce((max, r) => Math.max(max, r.timestamp), end);
-  json(res, readings, { 'X-Latest-Timestamp': String(latest) });
+function send(res: ServerResponse, method: string, path: string, query: URLSearchParams, body: unknown) {
+  const { status, body: out, headers } = handleRequest(method, path, query, body);
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  for (const [k, v] of Object.entries(headers ?? {})) res.setHeader(k, v);
+  res.end(JSON.stringify(out));
 }
 
 function handleApi(req: IncomingMessage, res: ServerResponse): boolean {
   const url = new URL(req.url ?? '/', 'http://localhost');
-  const path = url.pathname;
+  if (!url.pathname.startsWith('/api/')) return false;
   const method = (req.method ?? 'GET').toUpperCase();
 
-  if (!path.startsWith('/api/')) return false;
-
-  // --- reads used by the sensor explorer -------------------------------
-  if (method === 'GET' && path === '/api/sensors') {
-    return json(res, MOCK_DEVICES.map(deviceInfo)), true;
+  // Reads carry no body; writes need it parsed first.
+  if (method === 'GET' || method === 'DELETE') {
+    send(res, method, url.pathname, url.searchParams, null);
+  } else {
+    readBody(req, (body) => send(res, method, url.pathname, url.searchParams, body));
   }
-  if (method === 'GET' && path === '/api/readings') {
-    return handleReadings(url, res), true;
-  }
-  if (method === 'GET' && path === '/api/devices/state') {
-    return json(res, MOCK_DEVICES.map((d) => deviceState(d.device_id, d._seed))), true;
-  }
-
-  // --- floor plan tab --------------------------------------------------
-  if (method === 'GET' && path === '/api/floor-plan') {
-    return json(res, { svg_content: MOCK_FLOOR_PLAN_SVG, uploaded_at: now() }), true;
-  }
-  if (method === 'GET' && path === '/api/network/topology') {
-    return json(res, mockTopology()), true;
-  }
-  if (method === 'GET' && path === '/api/devices/positions') {
-    return json(res, mockPositions(positionOverrides)), true;
-  }
-  // Persist a dragged device position for this session.
-  if (method === 'PUT' && /^\/api\/devices\/.+\/position$/.test(path)) {
-    const deviceId = path.slice('/api/devices/'.length, -'/position'.length);
-    readBody(req, (body) => {
-      const { x, y } = (body ?? {}) as { x?: number; y?: number };
-      if (typeof x === 'number' && typeof y === 'number') {
-        positionOverrides[deviceId] = { x, y };
-      }
-      json(res, { ok: true });
-    });
-    return true;
-  }
-
-  // --- startup / other tabs: minimal but non-breaking answers ----------
-  if (method === 'GET' && path === '/api/devices/switches') return json(res, []), true;
-  if (method === 'GET' && path === '/api/automation/rules') return json(res, []), true;
-  if (method === 'GET' && path === '/api/automation/logs') return json(res, []), true;
-  if (method === 'GET' && path === '/api/system/storage') return json(res, {}), true;
-  if (method === 'GET' && path.startsWith('/api/logs/')) return json(res, []), true;
-
-  // --- writes: accept and echo success --------------------------------
-  if (method === 'POST' && path === '/api/commands/execute') return json(res, { ok: true }), true;
-  if (method === 'POST' && path === '/api/zigbee/permit_join') return json(res, { ok: true }), true;
-  if (method === 'POST' && path === '/api/network/refresh') return json(res, { ok: true }), true;
-  if (method === 'DELETE' && path === '/api/floor-plan') return json(res, { ok: true }), true;
-  if (method === 'PATCH' && path.startsWith('/api/devices/')) return json(res, { ok: true }), true;
-  if (method === 'PUT' && path.startsWith('/api/devices/')) return json(res, { ok: true }), true;
-
-  // Anything else under /api: safe empty payload so the UI never hard-fails.
-  json(res, []);
   return true;
 }
 
@@ -160,6 +57,13 @@ function setupWebSocket(server: ViteDevServer) {
 
   const wss = new WebSocketServer({ noServer: true });
   const clients = new Set<WebSocket>();
+
+  const broadcast = (message: unknown) => {
+    const payload = JSON.stringify(message);
+    for (const ws of clients) {
+      if (ws.readyState === ws.OPEN) ws.send(payload);
+    }
+  };
 
   httpServer.on('upgrade', (req, socket, head) => {
     const url = new URL(req.url ?? '/', 'http://localhost');
@@ -171,26 +75,18 @@ function setupWebSocket(server: ViteDevServer) {
     });
   });
 
-  // Push a live reading for a rotating device every few seconds.
-  let i = 0;
+  // Relay events pushed by the core (e.g. switch_state after a command).
+  const unsubscribe = onEvent(broadcast);
+
+  // Push a live sensor reading for a rotating device every few seconds.
   const timer = setInterval(() => {
     if (clients.size === 0) return;
-    const dev = MOCK_DEVICES[i % MOCK_DEVICES.length];
-    i += 1;
-    const t = now();
-    const message = JSON.stringify({
-      event: 'sensor_reading',
-      device_id: dev.device_id,
-      reading: readingAt(dev, t),
-      timestamp: t,
-    });
-    for (const ws of clients) {
-      if (ws.readyState === ws.OPEN) ws.send(message);
-    }
+    broadcast(nextSensorReading());
   }, 3000);
 
   httpServer.on('close', () => {
     clearInterval(timer);
+    unsubscribe();
     wss.close();
   });
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "dev": "vite",
     "dev:mock": "VITE_MOCK=1 vite",
     "build": "vite build",
+    "build:demo": "VITE_MOCK_BUILD=1 vite build",
+    "preview:demo": "VITE_MOCK_BUILD=1 vite preview",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.app.json"
   },

--- a/frontend/src/lib/api/energy.ts
+++ b/frontend/src/lib/api/energy.ts
@@ -1,0 +1,88 @@
+import { dateToUnixSeconds, unixSecondsToDate } from '../utils/time';
+
+/**
+ * Cumulative-energy summary for a period.
+ *
+ * The meter's `energy`/`produced_energy` are lifetime counters, so the server
+ * returns per-bucket **deltas** (consumption/production during the bucket), the
+ * period totals, and the peak instantaneous power. The totals always equal the
+ * sum of the buckets, so the histogram and the headline figure agree.
+ */
+export interface EnergyBucket {
+  /** Bucket start. */
+  timestamp: Date;
+  /** kWh consumed during the bucket. */
+  consumed: number;
+  /** kWh produced during the bucket. */
+  produced: number;
+}
+
+export interface EnergySummary {
+  start: Date;
+  end: Date;
+  bucketSeconds: number;
+  totalConsumed: number;
+  totalProduced: number;
+  /** Highest single power sample over the period (W). */
+  peakPower: number;
+  /** When the peak power occurred, or null if there is no data. */
+  peakPowerTimestamp: Date | null;
+  buckets: EnergyBucket[];
+}
+
+interface EnergySummaryResponse {
+  start: number;
+  end: number;
+  bucket_seconds: number;
+  total_consumed: number;
+  total_produced: number;
+  peak_power: number;
+  peak_power_timestamp: number | null;
+  buckets: { timestamp: number; consumed: number; produced: number }[];
+}
+
+export interface FetchEnergySummaryOptions {
+  /** Restrict to one meter; omit to aggregate across every energy meter. */
+  deviceId?: string;
+  start: Date;
+  end: Date;
+  /** Bucket size in seconds (e.g. 3600 for hourly, 86400 for daily). */
+  bucketSeconds: number;
+}
+
+/**
+ * Fetch a cumulative-energy summary from `/api/energy/summary`.
+ */
+export async function fetchEnergySummary(
+  opts: FetchEnergySummaryOptions,
+): Promise<EnergySummary> {
+  const params = new URLSearchParams();
+  if (opts.deviceId) params.append('device_id', opts.deviceId);
+  params.append('start', dateToUnixSeconds(opts.start).toString());
+  params.append('end', dateToUnixSeconds(opts.end).toString());
+  params.append('bucket', Math.max(1, Math.floor(opts.bucketSeconds)).toString());
+
+  const response = await fetch(`/api/energy/summary?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch energy summary: ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as EnergySummaryResponse;
+  return {
+    start: unixSecondsToDate(data.start),
+    end: unixSecondsToDate(data.end),
+    bucketSeconds: data.bucket_seconds,
+    totalConsumed: data.total_consumed,
+    totalProduced: data.total_produced,
+    peakPower: data.peak_power,
+    peakPowerTimestamp:
+      data.peak_power_timestamp != null
+        ? unixSecondsToDate(data.peak_power_timestamp)
+        : null,
+    buckets: data.buckets.map((b) => ({
+      timestamp: unixSecondsToDate(b.timestamp),
+      consumed: b.consumed,
+      produced: b.produced,
+    })),
+  };
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,5 +1,6 @@
 export * from './automation';
 export * from './devices';
+export * from './energy';
 export * from './floor-map';
 export * from './logs';
 export * from './network';

--- a/frontend/src/lib/device-detail/EnergyDetailPage.svelte
+++ b/frontend/src/lib/device-detail/EnergyDetailPage.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { push } from "svelte-spa-router";
+  import { formatDistanceToNow } from "date-fns";
+  import { fr } from "date-fns/locale";
   import { deviceStateMemory, sensorsMemory } from "../memory";
   import type { EnergySensorReading } from "../api/sensors";
   import type { DeviceInfo, DeviceState } from "../types/devices";
-  import { graphConfig, RECOMMENDED_COLORS } from "../stores/graphConfig";
   import StatusBadge from "../shared/StatusBadge.svelte";
-  import UnifiedChart from "../graphs/UnifiedChart.svelte";
   import EditableDeviceName from "../devices/EditableDeviceName.svelte";
-  import Gauge from "../design-system/Gauge.svelte";
+  import EnergyDashboard from "../devices/EnergyDashboard.svelte";
   import { URI_FRONTEND } from "../shared/constant/URI";
 
   interface Props {
@@ -17,223 +17,111 @@
 
   let { params }: Props = $props();
 
-  let device = $state<DeviceInfo | null>(null);
   let deviceState = $state<DeviceState | null>(null);
-  let loading = $state(true);
-  let error = $state<string | null>(null);
   let editingName = $state(false);
+  let device = $state<DeviceInfo | null>(null);
+  let triedLoad = $state(false);
 
-  // Time range state (local to this page)
-  type TimeRange = "24h" | "1w" | "1m" | "1y";
-  let timeRange = $state<TimeRange>("24h");
+  // Latch the device once it appears in the store. We don't derive it directly:
+  // the store's IndexedDB rehydration can transiently reset `devices` to empty,
+  // and we don't want that to blank an already-loaded page.
+  $effect(() => {
+    const found = $sensorsMemory.devices.find((d) => d.device_id === params.id);
+    if (found) device = found;
+  });
+  const notFound = $derived(triedLoad && !device);
 
-  // Get the latest reading for this energy meter
   const latestReading = $derived.by(() => {
     const reading = $sensorsMemory.latestByDevice[params.id] ?? null;
     if (!reading || reading.type !== "energy_meter") return null;
     return reading as EnergySensorReading;
   });
 
-  const powerMagnitude = $derived.by(() => {
-    if (latestReading?.power === undefined) return null;
-    return Math.abs(latestReading.power);
-  });
-
-  // Power flow direction
+  const powerMagnitude = $derived(
+    latestReading?.power !== undefined ? Math.abs(latestReading.power) : null,
+  );
   const isProducing = $derived((latestReading?.power ?? 0) < 0);
 
-  // Get sensor config for the chart
-  const sensorConfig = $derived([
-    {
-      deviceId: params.id,
-      color: device?.color || RECOMMENDED_COLORS[0],
-      visible: true,
-    },
-  ]);
+  const deviceName = $derived(device?.name ?? params.id);
 
-  const deviceName = $derived.by(() => {
-    const memoryDevice = $sensorsMemory.devices.find(
-      (d) => d.device_id === params.id,
-    );
-    return memoryDevice?.name ?? device?.name ?? params.id;
+  onMount(() => {
+    void sensorsMemory.ensureDevices().finally(() => {
+      triedLoad = true;
+    });
+    void sensorsMemory.refreshLatestReadings();
+    // Battery/signal badges are secondary — fetch without gating the page.
+    void deviceStateMemory
+      .ensureDeviceState(params.id)
+      .then((state) => {
+        if (state) deviceState = state;
+      })
+      .catch(() => {});
   });
 
-  onMount(async () => {
-    await loadData();
-  });
-
-  async function loadData() {
-    loading = true;
-    error = null;
-
-    try {
-      await sensorsMemory.ensureDevices();
-      // Find device info from sensors memory - energy meters are sensors
-      const deviceInfo = $sensorsMemory.devices.find(
-        (d) => d.device_id === params.id,
-      );
-
-      if (!deviceInfo) {
-        error = "Energy meter not found";
-        loading = false;
-        return;
-      }
-
-      device = deviceInfo;
-
-      // Fetch device state (battery, link quality)
-      const state = await deviceStateMemory.ensureDeviceState(params.id);
-      if (state) {
-        deviceState = state;
-      }
-
-      // Initialize graph config for this sensor
-      graphConfig.initializeSensors([
-        { deviceId: params.id, color: deviceInfo.color },
-      ]);
-      graphConfig.isolateSensor(params.id);
-
-      void sensorsMemory.ensureRecentReadings(params.id, 24);
-    } catch (err) {
-      console.error("Failed to load energy meter data:", err);
-      error =
-        err instanceof Error ? err.message : "Failed to load energy meter data";
-    } finally {
-      loading = false;
-    }
-  }
-
-  function handleTimeRangeChange(range: TimeRange) {
-    timeRange = range;
-    graphConfig.setTimeRange(range);
+  function goBack() {
+    push(URI_FRONTEND.CONSOMMATIONS);
   }
 
   function startEditingName() {
     editingName = true;
   }
-
   function handleNameSaved() {
     editingName = false;
-    const memoryDevice = $sensorsMemory.devices.find(
-      (d) => d.device_id === params.id,
-    );
-    if (memoryDevice) {
-      device = memoryDevice;
-    }
+    // `device` and `deviceName` are derived from the store, which the rename
+    // already updated — nothing to reassign here.
   }
 
-  function goBack() {
-    push(URI_FRONTEND.FLOORPLAN);
+  function lastSeen(): string {
+    const date = deviceState?.last_seen || latestReading?.timestamp;
+    // An invalid Date is still truthy, so guard on the time value too.
+    if (!date || Number.isNaN(date.getTime())) return "—";
+    const diff = Date.now() - date.getTime();
+    if (diff < 60_000) return "à l'instant";
+    return formatDistanceToNow(date, { addSuffix: true, locale: fr });
   }
 
-  function formatLastSeen(date: Date | null | undefined): string {
-    if (!date) return "Unknown";
-    const now = new Date();
-    const diff = now.getTime() - date.getTime();
-    const seconds = Math.floor(diff / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
+  const nf = (v: number | undefined, d = 1) =>
+    v === undefined
+      ? "—"
+      : v.toLocaleString("fr-FR", { minimumFractionDigits: d, maximumFractionDigits: d });
 
-    if (seconds < 60) return "Just now";
-    if (minutes < 60) return `${minutes}m ago`;
-    if (hours < 24) return `${hours}h ago`;
-    return date.toLocaleDateString();
+  function powerText(w: number | null): { value: string; unit: string } {
+    if (w === null) return { value: "—", unit: "W" };
+    return Math.abs(w) >= 1000
+      ? { value: nf(w / 1000, 2), unit: "kW" }
+      : { value: String(Math.round(w)), unit: "W" };
   }
-
-  function formatPower(value: number | undefined): string {
-    if (value === undefined) return "--";
-    if (Math.abs(value) >= 1000) {
-      return (value / 1000).toFixed(2);
-    }
-    return value.toFixed(0);
-  }
-
-  function formatPowerUnit(value: number | undefined): string {
-    if (value === undefined) return "W";
-    if (Math.abs(value) >= 1000) {
-      return "kW";
-    }
-    return "W";
-  }
-
-  function formatEnergy(value: number | undefined): string {
-    if (value === undefined) return "--";
-    return value.toFixed(2);
-  }
-
-  function formatVoltage(value: number | undefined): string {
-    if (value === undefined) return "--";
-    return value.toFixed(1);
-  }
-
-  function formatCurrent(value: number | undefined): string {
-    if (value === undefined) return "--";
-    return value.toFixed(2);
-  }
-
-  function formatFrequency(value: number | undefined): string {
-    if (value === undefined) return "--";
-    return value.toFixed(1);
-  }
-
-  function formatPowerFactor(value: number | undefined): string {
-    if (value === undefined) return "--";
-    return value.toFixed(2);
-  }
+  const powerDisplay = $derived(powerText(powerMagnitude));
 </script>
 
-<div class="energy-detail-page">
-  <!-- Ambient background -->
-  <div class="ambient-bg"></div>
-  <div class="grid-overlay"></div>
-
-  <header class="page-header">
-    <button class="back-button" onclick={goBack} type="button">
-      <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18">
-        <path
-          d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-        />
-      </svg>
-      <span>Back</span>
-    </button>
-  </header>
-
-  {#if loading}
-    <div class="loading-state">
-      <div class="loading-ring">
-        <div class="ring-segment"></div>
-        <div class="ring-segment"></div>
-        <div class="ring-segment"></div>
-      </div>
-      <p class="loading-text">Connecting to energy meter...</p>
-    </div>
-  {:else if error}
-    <div class="error-state">
-      <div class="error-icon">
-        <svg viewBox="0 0 24 24" fill="currentColor" width="48" height="48">
-          <path
-            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
-          />
+<div class="energy-detail">
+  <div class="board">
+    <header class="detail-header">
+      <button class="back-button" onclick={goBack} type="button">
+        <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18">
+          <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
         </svg>
-      </div>
-      <p class="error-text">{error}</p>
-      <button class="retry-btn" onclick={loadData} type="button">
-        Retry Connection
+        <span>Consommations</span>
       </button>
-    </div>
-  {:else if device}
-    <div class="content">
-      <!-- Device Identity Section -->
-      <section class="device-identity">
-        <div class="identity-icon">
-          <svg viewBox="0 0 24 24" fill="currentColor" width="32" height="32">
-            <path
-              d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66.19-.34.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.5c.49 0 .56.33.47.51l-.07.15C12.96 17.55 11 21 11 21z"
-            />
-          </svg>
-          <div class="power-pulse"></div>
-        </div>
+    </header>
 
+    {#if notFound}
+      <div class="panel state-panel">
+        <p class="state-msg">Compteur d'énergie introuvable</p>
+        <button class="retry" onclick={goBack} type="button">Retour</button>
+      </div>
+    {:else if !device}
+      <div class="panel state-panel">
+        <p class="state-msg">Chargement du compteur…</p>
+      </div>
+    {:else}
+      <!-- Identity -->
+      <section class="panel identity">
+        <div class="identity-icon">
+          <svg viewBox="0 0 24 24" fill="currentColor" width="26" height="26">
+            <path d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66.19-.34.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.5c.49 0 .56.33.47.51l-.07.15C12.96 17.55 11 21 11 21z" />
+          </svg>
+        </div>
         <div class="identity-details">
           <h1 class="device-name">
             <EditableDeviceName
@@ -244,38 +132,20 @@
               class="device-name-text"
             />
             {#if !editingName}
-              <button
-                class="edit-trigger"
-                onclick={startEditingName}
-                title="Edit name"
-                type="button"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  width="16"
-                  height="16"
-                >
-                  <path
-                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                  />
+              <button class="edit-trigger" onclick={startEditingName} title="Renommer" type="button">
+                <svg viewBox="0 0 24 24" fill="currentColor" width="15" height="15">
+                  <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
                 </svg>
               </button>
             {/if}
           </h1>
-
           <div class="identity-meta">
             <span class="device-id">{params.id}</span>
-            <span class="meta-divider">•</span>
-            <span class="last-seen">
-              {formatLastSeen(
-                deviceState?.last_seen || latestReading?.timestamp,
-              )}
-            </span>
+            <span class="dot-sep">•</span>
+            <span>{lastSeen()}</span>
           </div>
         </div>
-
-        <div class="device-badges">
+        <div class="badges">
           {#if deviceState?.battery_level != null}
             <StatusBadge type="battery" value={deviceState.battery_level} />
           {/if}
@@ -285,1045 +155,276 @@
         </div>
       </section>
 
-      <!-- Power Display Hero -->
-      <section class="power-hero">
-        <div class="power-gauge">
-          <Gauge
-            value={powerMagnitude}
-            min={0}
-            max={6000}
-            tone={isProducing ? "good" : "info"}
-            label=""
-            size="lg"
-            unit={powerMagnitude === null
-              ? ""
-              : formatPowerUnit(powerMagnitude)}
-            format={(value) => formatPower(value)}
-            style="--gauge-stroke: 12; --gauge-track: rgba(255, 255, 255, 0.12); --gauge-text: #f1f5f9; --gauge-subtle: rgba(255, 255, 255, 0.5);"
-          >
-            {#snippet center()}
-              <div class="power-value">
-                <span class="value-number"
-                  >{formatPower(powerMagnitude ?? undefined)}</span
-                >
-                <span class="value-unit"
-                  >{formatPowerUnit(powerMagnitude ?? undefined)}</span
-                >
-              </div>
-            {/snippet}
-          </Gauge>
-          <div class="flow-indicator" class:producing={isProducing}>
-            <span class="flow-arrow">{isProducing ? "↑" : "↓"}</span>
-            <span class="flow-label"
-              >{isProducing ? "PRODUCING" : "CONSUMING"}</span
-            >
+      <!-- Live now -->
+      <section class="panel live">
+        <div class="live-power">
+          <span class="live-label">Puissance en direct</span>
+          <div class="power-value">
+            <span class="pv-number">{powerDisplay.value}</span>
+            <span class="pv-unit">{powerDisplay.unit}</span>
           </div>
-        </div>
-      </section>
-
-      <!-- Live Metrics Grid -->
-      <section class="metrics-section">
-        <h2 class="section-header">
-          <span class="header-icon">
-            <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18">
-              <path
-                d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM7 10h2v7H7zm4-3h2v10h-2zm4 6h2v4h-2z"
-              />
-            </svg>
+          <span class="flow" class:producing={isProducing}>
+            {isProducing ? "↑ Production" : "↓ Consommation"}
           </span>
-          Live Metrics
-        </h2>
-
-        <div class="metrics-grid">
-          <div class="metric-card voltage">
-            <div class="metric-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                width="20"
-                height="20"
-              >
-                <path
-                  d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66.19-.34.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.5c.49 0 .56.33.47.51l-.07.15C12.96 17.55 11 21 11 21z"
-                />
-              </svg>
-            </div>
-            <div class="metric-data">
-              <span class="metric-value"
-                >{formatVoltage(latestReading?.voltage)}</span
-              >
-              <span class="metric-unit">V</span>
-            </div>
-            <span class="metric-label">Voltage</span>
+        </div>
+        <div class="live-metrics">
+          <div class="metric">
+            <span class="m-value">{nf(latestReading?.voltage, 1)}<span class="m-unit">V</span></span>
+            <span class="m-label">Tension</span>
           </div>
-
-          <div class="metric-card current">
-            <div class="metric-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                width="20"
-                height="20"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm.31-8.86c-1.77-.45-2.34-.94-2.34-1.67 0-.84.79-1.43 2.1-1.43 1.38 0 1.9.66 1.94 1.64h1.71c-.05-1.34-.87-2.57-2.49-2.97V5H10.9v1.69c-1.51.32-2.72 1.3-2.72 2.81 0 1.79 1.49 2.69 3.66 3.21 1.95.46 2.34 1.15 2.34 1.87 0 .53-.39 1.39-2.1 1.39-1.6 0-2.23-.72-2.32-1.64H8.04c.1 1.7 1.36 2.66 2.86 2.97V19h2.34v-1.67c1.52-.29 2.72-1.16 2.73-2.77-.01-2.2-1.9-2.96-3.66-3.42z"
-                />
-              </svg>
-            </div>
-            <div class="metric-data">
-              <span class="metric-value"
-                >{formatCurrent(latestReading?.current)}</span
-              >
-              <span class="metric-unit">A</span>
-            </div>
-            <span class="metric-label">Current</span>
+          <div class="metric">
+            <span class="m-value">{nf(latestReading?.current, 2)}<span class="m-unit">A</span></span>
+            <span class="m-label">Courant</span>
           </div>
-
-          <div class="metric-card frequency">
-            <div class="metric-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                width="20"
-                height="20"
-              >
-                <path
-                  d="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z"
-                />
-              </svg>
-            </div>
-            <div class="metric-data">
-              <span class="metric-value"
-                >{formatFrequency(latestReading?.ac_frequency)}</span
-              >
-              <span class="metric-unit">Hz</span>
-            </div>
-            <span class="metric-label">AC Frequency</span>
+          <div class="metric">
+            <span class="m-value">{nf(latestReading?.ac_frequency, 1)}<span class="m-unit">Hz</span></span>
+            <span class="m-label">Fréquence</span>
           </div>
-
-          <div class="metric-card power-factor">
-            <div class="metric-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                width="20"
-                height="20"
-              >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1.41 16.09V20h-2.67v-1.93c-1.71-.36-3.16-1.46-3.27-3.4h1.96c.1 1.05.82 1.87 2.65 1.87 1.96 0 2.4-.98 2.4-1.59 0-.83-.44-1.61-2.67-2.14-2.48-.6-4.18-1.62-4.18-3.67 0-1.72 1.39-2.84 3.11-3.21V4h2.67v1.95c1.86.45 2.79 1.86 2.85 3.39H14.3c-.05-1.11-.64-1.87-2.22-1.87-1.5 0-2.4.68-2.4 1.64 0 .84.65 1.39 2.67 1.91s4.18 1.39 4.18 3.91c-.01 1.83-1.38 2.83-3.12 3.16z"
-                />
-              </svg>
-            </div>
-            <div class="metric-data">
-              <span class="metric-value"
-                >{formatPowerFactor(latestReading?.power_factor)}</span
-              >
-              <span class="metric-unit">PF</span>
-            </div>
-            <span class="metric-label">Power Factor</span>
+          <div class="metric">
+            <span class="m-value">{nf(latestReading?.power_factor, 2)}</span>
+            <span class="m-label">Facteur de puissance</span>
           </div>
         </div>
       </section>
 
-      <!-- Energy Totals -->
-      <section class="energy-totals">
-        <h2 class="section-header">
-          <span class="header-icon">
-            <svg viewBox="0 0 24 24" fill="currentColor" width="18" height="18">
-              <path
-                d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66.19-.34.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.5c.49 0 .56.33.47.51l-.07.15C12.96 17.55 11 21 11 21z"
-              />
-            </svg>
-          </span>
-          Energy Totals
-        </h2>
-
-        <div class="energy-cards">
-          <div class="energy-card consumed">
-            <div class="energy-visual">
-              <div class="energy-bar">
-                <div class="bar-fill"></div>
-              </div>
-              <svg
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                width="24"
-                height="24"
-                class="energy-icon"
-              >
-                <path
-                  d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"
-                />
-              </svg>
-            </div>
-            <div class="energy-info">
-              <span class="energy-label">Consumed</span>
-              <div class="energy-value">
-                <span class="value">{formatEnergy(latestReading?.energy)}</span>
-                <span class="unit">kWh</span>
-              </div>
-            </div>
-          </div>
-
-          <div class="energy-card produced">
-            <div class="energy-visual">
-              <div class="energy-bar">
-                <div class="bar-fill"></div>
-              </div>
-              <svg
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                width="24"
-                height="24"
-                class="energy-icon"
-              >
-                <path
-                  d="M16 18l2.29-2.29-4.88-4.88-4 4L2 7.41 3.41 6l6 6 4-4 6.3 6.29L22 12v6z"
-                />
-              </svg>
-            </div>
-            <div class="energy-info">
-              <span class="energy-label">Produced</span>
-              <div class="energy-value">
-                <span class="value"
-                  >{formatEnergy(latestReading?.produced_energy)}</span
-                >
-                <span class="unit">kWh</span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- Chart Section -->
-      <section class="chart-section">
-        <div class="chart-header">
-          <h2 class="section-header">
-            <span class="header-icon">
-              <svg
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                width="18"
-                height="18"
-              >
-                <path
-                  d="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z"
-                />
-              </svg>
-            </span>
-            Power History
-          </h2>
-
-          <div class="time-range-selector">
-            {#each ["24h", "1w", "1m", "1y"] as range}
-              <button
-                class="range-btn"
-                class:active={timeRange === range}
-                onclick={() => handleTimeRangeChange(range as TimeRange)}
-                type="button"
-              >
-                {range}
-              </button>
-            {/each}
-          </div>
-        </div>
-
-        <div class="chart-container">
-          <UnifiedChart sensors={sensorConfig} {timeRange} metricType="power" />
-        </div>
-      </section>
-    </div>
-  {/if}
+      <!-- Cumulative dashboard, scoped to this meter -->
+      <EnergyDashboard deviceId={params.id} />
+    {/if}
+  </div>
 </div>
 
 <style>
-  .energy-detail-page {
-    position: relative;
-    min-height: 100vh;
-    background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%);
-    padding: 1.5rem;
-    overflow: hidden;
+  .energy-detail {
+    width: 100%;
+    height: 100%;
+  }
+  .board {
+    padding: 1.25rem;
+    background: #eef1f5;
+    border-radius: 18px;
+    margin: 1.25rem;
+    min-height: calc(100vh - var(--app-header-height, 88px) - 2.5rem);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
   }
 
-  /* Ambient background effects */
-  .ambient-bg {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: radial-gradient(
-        ellipse 80% 50% at 50% -20%,
-        rgba(6, 182, 212, 0.15),
-        transparent
-      ),
-      radial-gradient(
-        ellipse 60% 40% at 80% 100%,
-        rgba(59, 130, 246, 0.1),
-        transparent
-      );
-    pointer-events: none;
-    z-index: 0;
+  .detail-header {
+    display: flex;
   }
-
-  .grid-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-image: linear-gradient(
-        rgba(6, 182, 212, 0.03) 1px,
-        transparent 1px
-      ),
-      linear-gradient(90deg, rgba(6, 182, 212, 0.03) 1px, transparent 1px);
-    background-size: 40px 40px;
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .page-header {
-    position: relative;
-    z-index: 1;
-    margin-bottom: 1.5rem;
-  }
-
   .back-button {
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.625rem 1rem;
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 8px;
-    font-family: "SF Mono", "Fira Code", monospace;
+    padding: 0.5rem 0.9rem;
+    background: #fff;
+    border: 1px solid var(--color-card-border);
+    border-radius: 9px;
     font-size: 0.8125rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.7);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    backdrop-filter: blur(8px);
-  }
-
-  .back-button:hover {
-    background: rgba(255, 255, 255, 0.1);
-    border-color: rgba(6, 182, 212, 0.3);
-    color: #06b6d4;
-  }
-
-  /* Loading state */
-  .loading-state {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 6rem 2rem;
-  }
-
-  .loading-ring {
-    position: relative;
-    width: 80px;
-    height: 80px;
-    margin-bottom: 1.5rem;
-  }
-
-  .ring-segment {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    border: 3px solid transparent;
-    border-top-color: #06b6d4;
-    border-radius: 50%;
-    animation: spin 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
-  }
-
-  .ring-segment:nth-child(2) {
-    animation-delay: -0.4s;
-    border-top-color: #0ea5e9;
-  }
-
-  .ring-segment:nth-child(3) {
-    animation-delay: -0.8s;
-    border-top-color: #3b82f6;
-  }
-
-  @keyframes spin {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-
-  .loading-text {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.875rem;
-    color: rgba(255, 255, 255, 0.5);
-    letter-spacing: 0.05em;
-  }
-
-  /* Error state */
-  .error-state {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 4rem 2rem;
-    text-align: center;
-  }
-
-  .error-icon {
-    color: #ef4444;
-    margin-bottom: 1rem;
-    opacity: 0.8;
-  }
-
-  .error-text {
-    font-size: 1rem;
-    color: rgba(255, 255, 255, 0.7);
-    margin-bottom: 1.5rem;
-  }
-
-  .retry-btn {
-    padding: 0.75rem 1.5rem;
-    background: linear-gradient(135deg, #06b6d4, #0ea5e9);
-    border: none;
-    border-radius: 8px;
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.875rem;
     font-weight: 600;
-    color: white;
+    color: #667085;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: all 0.15s;
+    box-shadow: var(--shadow-sm);
+  }
+  .back-button:hover {
+    color: #101828;
   }
 
-  .retry-btn:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 8px 20px rgba(6, 182, 212, 0.3);
+  .panel {
+    background: var(--color-card-bg);
+    border-radius: 14px;
+    box-shadow: var(--shadow-sm);
   }
 
-  /* Content */
-  .content {
-    position: relative;
-    z-index: 1;
-    max-width: 900px;
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-  }
-
-  /* Device Identity */
-  .device-identity {
+  /* Identity */
+  .identity {
     display: flex;
     align-items: center;
     gap: 1rem;
-    padding: 1.25rem 1.5rem;
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 16px;
-    backdrop-filter: blur(12px);
+    padding: 1.1rem 1.25rem;
   }
-
   .identity-icon {
-    position: relative;
-    width: 56px;
-    height: 56px;
-    background: linear-gradient(
-      135deg,
-      rgba(6, 182, 212, 0.2),
-      rgba(59, 130, 246, 0.2)
-    );
-    border: 1px solid rgba(6, 182, 212, 0.3);
-    border-radius: 14px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #06b6d4;
+    width: 48px;
+    height: 48px;
     flex-shrink: 0;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    color: #d97706;
+    background: linear-gradient(135deg, #fffbeb, #fef3c7);
+    border: 1px solid #fde68a;
   }
-
-  .power-pulse {
-    position: absolute;
-    inset: -4px;
-    border: 2px solid rgba(6, 182, 212, 0.4);
-    border-radius: 18px;
-    animation: pulse-ring 2s ease-out infinite;
-  }
-
-  @keyframes pulse-ring {
-    0% {
-      transform: scale(1);
-      opacity: 1;
-    }
-    100% {
-      transform: scale(1.2);
-      opacity: 0;
-    }
-  }
-
   .identity-details {
     flex: 1;
     min-width: 0;
   }
-
   .device-name {
-    font-family:
-      "SF Pro Display",
-      -apple-system,
-      sans-serif;
-    font-size: 1.375rem;
-    font-weight: 600;
-    color: #f1f5f9;
-    margin: 0 0 0.25rem;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.4rem;
+    margin: 0 0 0.15rem;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #101828;
   }
-
+  :global(.device-name-text) {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #101828;
+  }
   .edit-trigger {
-    padding: 0.375rem;
+    padding: 0.3rem;
     background: transparent;
     border: none;
     border-radius: 6px;
-    color: rgba(255, 255, 255, 0.3);
+    color: #98a2b3;
     cursor: pointer;
-    transition: all 0.15s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    display: grid;
+    place-items: center;
+    transition: all 0.15s;
   }
-
   .edit-trigger:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: rgba(255, 255, 255, 0.7);
+    background: #f2f4f7;
+    color: #667085;
   }
-
   .identity-meta {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    font-size: 0.8125rem;
-    color: rgba(255, 255, 255, 0.4);
+    font-size: 0.8rem;
+    color: #98a2b3;
   }
-
   .device-id {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.75rem;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
   }
-
-  .meta-divider {
-    opacity: 0.3;
+  .dot-sep {
+    opacity: 0.5;
   }
-
-  .device-badges {
+  .badges {
     display: flex;
     gap: 0.5rem;
     flex-shrink: 0;
   }
 
-  :global(.device-name-text) {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: #f8fafc;
-  }
-
-  /* Power Hero Section */
-  .power-hero {
+  /* Live */
+  .live {
     display: flex;
+    align-items: stretch;
+    gap: 1.25rem;
+    padding: 1.25rem;
+    flex-wrap: wrap;
+  }
+  .live-power {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
     justify-content: center;
-    padding: 2rem;
-    background: rgba(255, 255, 255, 0.02);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 20px;
-    backdrop-filter: blur(12px);
+    min-width: 150px;
   }
-
-  .power-gauge {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .power-gauge :global(.gauge),
-  .power-gauge :global(.gauge-ring),
-  .power-gauge :global(.gauge-ring svg) {
-    overflow: visible;
-  }
-
-  .power-gauge :global(.gauge-center) {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    gap: 0.5rem;
-    padding: 0 1rem;
-  }
-
-  .flow-indicator {
-    display: flex;
-    align-items: center;
-    gap: 0.375rem;
-    padding: 0.25rem 0.625rem;
-    background: rgba(6, 182, 212, 0.15);
-    border: 1px solid rgba(6, 182, 212, 0.3);
-    border-radius: 20px;
-    margin-bottom: 0.75rem;
-  }
-
-  .flow-indicator.producing {
-    background: rgba(34, 197, 94, 0.15);
-    border-color: rgba(34, 197, 94, 0.3);
-  }
-
-  .flow-arrow {
-    font-size: 0.875rem;
-    color: #06b6d4;
-    animation: flow-bounce 1.5s ease-in-out infinite;
-  }
-
-  .flow-indicator.producing .flow-arrow {
-    color: #22c55e;
-  }
-
-  @keyframes flow-bounce {
-    0%,
-    100% {
-      transform: translateY(0);
-    }
-    50% {
-      transform: translateY(-2px);
-    }
-  }
-
-  .flow-label {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.625rem;
+  .live-label {
+    font-size: 0.72rem;
     font-weight: 600;
-    letter-spacing: 0.1em;
-    color: #06b6d4;
+    color: #667085;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
   }
-
-  .flow-indicator.producing .flow-label {
-    color: #22c55e;
-  }
-
   .power-value {
     display: flex;
     align-items: baseline;
-    gap: 0.25rem;
+    gap: 0.35rem;
   }
-
-  .value-number {
-    font-family:
-      "SF Pro Display",
-      -apple-system,
-      sans-serif;
-    font-size: 3rem;
-    font-weight: 700;
-    color: #f1f5f9;
-    letter-spacing: -0.02em;
+  .pv-number {
+    font-size: 2.6rem;
     line-height: 1;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    color: #101828;
+    font-variant-numeric: tabular-nums;
   }
-
-  .value-unit {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 1.25rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.5);
-  }
-
-  .power-gauge :global(.gauge-label) {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.6875rem;
-    color: rgba(255, 255, 255, 0.35);
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-  }
-
-  /* Metrics Section */
-  .metrics-section,
-  .energy-totals,
-  .chart-section {
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 16px;
-    backdrop-filter: blur(12px);
-    padding: 1.5rem;
-  }
-
-  .section-header {
-    display: flex;
-    align-items: center;
-    gap: 0.625rem;
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.8125rem;
+  .pv-unit {
+    font-size: 1rem;
     font-weight: 600;
-    color: rgba(255, 255, 255, 0.6);
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    margin: 0 0 1.25rem;
+    color: #98a2b3;
   }
-
-  .header-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    background: rgba(6, 182, 212, 0.15);
-    border-radius: 6px;
-    color: #06b6d4;
+  .flow {
+    width: fit-content;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    background: #eff6ff;
+    color: #1d4ed8;
   }
-
-  .metrics-grid {
+  .flow.producing {
+    background: #ecfdf3;
+    color: #16a34a;
+  }
+  .live-metrics {
+    flex: 1;
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: 1rem;
+    gap: 0.75rem;
+    min-width: 0;
   }
-
-  .metric-card {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 1.25rem 1rem;
-    background: rgba(0, 0, 0, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 12px;
-    text-align: center;
-    transition: all 0.2s ease;
-  }
-
-  .metric-card:hover {
-    background: rgba(0, 0, 0, 0.3);
-    border-color: rgba(6, 182, 212, 0.2);
-  }
-
-  .metric-icon {
-    width: 36px;
-    height: 36px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  .metric {
+    background: #f9fafb;
+    border: 1px solid #f1f3f5;
     border-radius: 10px;
-    color: white;
-  }
-
-  .metric-card.voltage .metric-icon {
-    background: linear-gradient(
-      135deg,
-      rgba(139, 92, 246, 0.3),
-      rgba(139, 92, 246, 0.1)
-    );
-    color: #a78bfa;
-  }
-
-  .metric-card.current .metric-icon {
-    background: linear-gradient(
-      135deg,
-      rgba(34, 197, 94, 0.3),
-      rgba(34, 197, 94, 0.1)
-    );
-    color: #4ade80;
-  }
-
-  .metric-card.frequency .metric-icon {
-    background: linear-gradient(
-      135deg,
-      rgba(251, 191, 36, 0.3),
-      rgba(251, 191, 36, 0.1)
-    );
-    color: #fbbf24;
-  }
-
-  .metric-card.power-factor .metric-icon {
-    background: linear-gradient(
-      135deg,
-      rgba(59, 130, 246, 0.3),
-      rgba(59, 130, 246, 0.1)
-    );
-    color: #60a5fa;
-  }
-
-  .metric-data {
-    display: flex;
-    align-items: baseline;
-    gap: 0.125rem;
-  }
-
-  .metric-value {
-    font-family:
-      "SF Pro Display",
-      -apple-system,
-      sans-serif;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: #f1f5f9;
-    letter-spacing: -0.01em;
-  }
-
-  .metric-unit {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.4);
-  }
-
-  .metric-label {
-    font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.4);
-  }
-
-  /* Energy Totals */
-  .energy-cards {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
-  }
-
-  .energy-card {
-    display: flex;
-    gap: 1rem;
-    padding: 1.25rem;
-    background: rgba(0, 0, 0, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 12px;
-  }
-
-  .energy-visual {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 48px;
-    height: 48px;
-    flex-shrink: 0;
-  }
-
-  .energy-bar {
-    position: absolute;
-    inset: 0;
-    border-radius: 12px;
-    overflow: hidden;
-  }
-
-  .energy-card.consumed .energy-bar {
-    background: rgba(6, 182, 212, 0.1);
-    border: 1px solid rgba(6, 182, 212, 0.2);
-  }
-
-  .energy-card.produced .energy-bar {
-    background: rgba(34, 197, 94, 0.1);
-    border: 1px solid rgba(34, 197, 94, 0.2);
-  }
-
-  .bar-fill {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 60%;
-    transition: height 0.5s ease;
-  }
-
-  .energy-card.consumed .bar-fill {
-    background: linear-gradient(
-      to top,
-      rgba(6, 182, 212, 0.4),
-      rgba(6, 182, 212, 0.1)
-    );
-  }
-
-  .energy-card.produced .bar-fill {
-    background: linear-gradient(
-      to top,
-      rgba(34, 197, 94, 0.4),
-      rgba(34, 197, 94, 0.1)
-    );
-  }
-
-  .energy-icon {
-    position: relative;
-    z-index: 1;
-  }
-
-  .energy-card.consumed .energy-icon {
-    color: #06b6d4;
-  }
-
-  .energy-card.produced .energy-icon {
-    color: #22c55e;
-  }
-
-  .energy-info {
+    padding: 0.75rem;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    gap: 0.3rem;
+    align-items: flex-start;
   }
-
-  .energy-label {
-    font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.4);
-    margin-bottom: 0.25rem;
-  }
-
-  .energy-value {
-    display: flex;
-    align-items: baseline;
-    gap: 0.25rem;
-  }
-
-  .energy-value .value {
-    font-family:
-      "SF Pro Display",
-      -apple-system,
-      sans-serif;
-    font-size: 1.5rem;
+  .m-value {
+    font-size: 1.15rem;
     font-weight: 700;
-    color: #f1f5f9;
+    color: #101828;
+    font-variant-numeric: tabular-nums;
+  }
+  .m-unit {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #98a2b3;
+    margin-left: 0.15rem;
+  }
+  .m-label {
+    font-size: 0.72rem;
+    color: #98a2b3;
   }
 
-  .energy-value .unit {
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.4);
-  }
-
-  /* Chart Section */
-  .chart-header {
+  /* States */
+  .state-panel {
+    padding: 2.5rem 1.25rem;
+    text-align: center;
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: space-between;
-    margin-bottom: 1rem;
-    flex-wrap: wrap;
-    gap: 1rem;
+    gap: 0.85rem;
   }
-
-  .chart-header .section-header {
+  .state-msg {
     margin: 0;
+    color: #667085;
   }
-
-  .time-range-selector {
-    display: flex;
-    gap: 0.25rem;
-    padding: 0.25rem;
-    background: rgba(0, 0, 0, 0.3);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+  .retry {
+    padding: 0.5rem 1.1rem;
+    border: 1px solid var(--color-card-border);
+    background: #fff;
     border-radius: 8px;
-  }
-
-  .range-btn {
-    padding: 0.5rem 0.875rem;
-    background: transparent;
-    border: none;
-    border-radius: 6px;
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.5);
+    font-weight: 600;
+    color: #101828;
     cursor: pointer;
-    transition: all 0.15s ease;
   }
 
-  .range-btn:hover {
-    color: rgba(255, 255, 255, 0.8);
-    background: rgba(255, 255, 255, 0.05);
-  }
-
-  .range-btn.active {
-    background: #06b6d4;
-    color: white;
-    box-shadow: 0 2px 8px rgba(6, 182, 212, 0.3);
-  }
-
-  .chart-container {
-    height: 400px;
-    background: rgba(0, 0, 0, 0.2);
-    border-radius: 12px;
-    overflow: hidden;
-  }
-
-  /* Responsive */
-  @media (max-width: 768px) {
-    .energy-detail-page {
-      padding: 1rem;
+  @media (max-width: 760px) {
+    .board {
+      padding: 0.75rem;
+      margin: 0.75rem;
     }
-
-    .device-identity {
-      flex-wrap: wrap;
-    }
-
-    .device-badges {
-      width: 100%;
-      justify-content: flex-start;
-      margin-top: 0.5rem;
-    }
-
-    .power-gauge {
-      width: 200px;
-      height: 200px;
-    }
-
-    .value-number {
-      font-size: 2.5rem;
-    }
-
-    .metrics-grid {
+    .live-metrics {
       grid-template-columns: repeat(2, 1fr);
-    }
-
-    .energy-cards {
-      grid-template-columns: 1fr;
-    }
-
-    .chart-header {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .time-range-selector {
-      justify-content: center;
-    }
-
-    .chart-container {
-      height: 300px;
-    }
-  }
-
-  @media (max-width: 480px) {
-    .power-hero {
-      padding: 1.5rem 1rem;
-    }
-
-    .power-gauge {
-      width: 180px;
-      height: 180px;
-    }
-
-    .value-number {
-      font-size: 2rem;
-    }
-
-    .metrics-grid {
-      grid-template-columns: 1fr;
-    }
-
-    .metric-card {
-      flex-direction: row;
-      text-align: left;
-      padding: 1rem;
-    }
-
-    .metric-icon {
-      flex-shrink: 0;
-    }
-
-    .chart-container {
-      height: 250px;
     }
   }
 </style>

--- a/frontend/src/lib/devices/EnergyDashboard.svelte
+++ b/frontend/src/lib/devices/EnergyDashboard.svelte
@@ -1,0 +1,852 @@
+<script lang="ts">
+  import {
+    startOfDay,
+    addDays,
+    startOfWeek,
+    addWeeks,
+    startOfMonth,
+    addMonths,
+    format,
+  } from "date-fns";
+  import { fr } from "date-fns/locale";
+  import { fetchEnergySummary, type EnergySummary } from "../api/energy";
+  import type { DeviceInfo } from "../types/devices";
+  import { sensorsMemory } from "../memory";
+
+  type Scope = "day" | "week" | "month";
+
+  let { deviceId }: { deviceId?: string } = $props();
+
+  // ---- period selection ----------------------------------------------------
+  let scope = $state<Scope>("month");
+  let offset = $state(0); // 0 = current period, -1 = previous, …
+
+  interface Period {
+    start: Date;
+    end: Date;
+    bucketSeconds: number;
+    label: string;
+    subLabel: "heure" | "jour";
+  }
+
+  function periodFor(s: Scope, o: number): Period {
+    const now = new Date();
+    if (s === "day") {
+      const start = addDays(startOfDay(now), o);
+      return {
+        start,
+        end: addDays(start, 1),
+        bucketSeconds: 3600,
+        label: format(start, "EEE d MMMM", { locale: fr }),
+        subLabel: "heure",
+      };
+    }
+    if (s === "week") {
+      const start = addWeeks(startOfWeek(now, { weekStartsOn: 1 }), o);
+      const last = addDays(start, 6);
+      return {
+        start,
+        end: addWeeks(start, 1),
+        bucketSeconds: 86400,
+        label: `${format(start, "d MMM", { locale: fr })} – ${format(last, "d MMM", { locale: fr })}`,
+        subLabel: "jour",
+      };
+    }
+    const start = addMonths(startOfMonth(now), o);
+    return {
+      start,
+      end: addMonths(start, 1),
+      bucketSeconds: 86400,
+      label: format(start, "MMMM yyyy", { locale: fr }),
+      subLabel: "jour",
+    };
+  }
+
+  const period = $derived(periodFor(scope, offset));
+  const atCurrent = $derived(offset >= 0);
+
+  function setScope(s: Scope) {
+    scope = s;
+    offset = 0;
+  }
+
+  // ---- data ----------------------------------------------------------------
+  let summary = $state<EnergySummary | null>(null);
+  let previousTotal = $state<number | null>(null);
+  let breakdown = $state<{ name: string; color: string; consumed: number }[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+
+  const isEnergyMeter = (d: DeviceInfo) =>
+    d.capabilities.some(
+      (c) => c.type === "sensor" && c.sensor_type === "energy_meter",
+    );
+
+  let reqToken = 0;
+
+  async function load(p: Period, dev: string | undefined) {
+    const token = ++reqToken;
+    loading = true;
+    error = null;
+    try {
+      const spanSec = Math.round((p.end.getTime() - p.start.getTime()) / 1000);
+      const prev = periodFor(scope, offset - 1);
+
+      const [cur, prevSum] = await Promise.all([
+        fetchEnergySummary({
+          deviceId: dev,
+          start: p.start,
+          end: p.end,
+          bucketSeconds: p.bucketSeconds,
+        }),
+        // Previous period total only — one big bucket keeps it cheap.
+        fetchEnergySummary({
+          deviceId: dev,
+          start: prev.start,
+          end: prev.end,
+          bucketSeconds: spanSec,
+        }),
+      ]);
+
+      if (token !== reqToken) return;
+      summary = cur;
+      previousTotal = prevSum.totalConsumed;
+
+      // Per-meter breakdown only makes sense in aggregate mode with ≥2 meters.
+      if (!dev) {
+        const meters = $sensorsMemory.devices.filter(isEnergyMeter);
+        if (meters.length >= 2) {
+          const perDevice = await Promise.all(
+            meters.map((m) =>
+              fetchEnergySummary({
+                deviceId: m.device_id,
+                start: p.start,
+                end: p.end,
+                bucketSeconds: spanSec,
+              }).then((s) => ({
+                name: m.name,
+                color: m.color ?? "#3b82f6",
+                consumed: s.totalConsumed,
+              })),
+            ),
+          );
+          if (token !== reqToken) return;
+          breakdown = perDevice
+            .filter((d) => d.consumed > 0)
+            .sort((a, b) => b.consumed - a.consumed);
+        } else {
+          breakdown = [];
+        }
+      } else {
+        breakdown = [];
+      }
+    } catch (err) {
+      if (token !== reqToken) return;
+      error = err instanceof Error ? err.message : "Échec du chargement";
+    } finally {
+      if (token === reqToken) loading = false;
+    }
+  }
+
+  $effect(() => {
+    // Re-fetch whenever the period or the target device changes.
+    void sensorsMemory.ensureDevices();
+    load(period, deviceId);
+  });
+
+  // ---- derived figures -----------------------------------------------------
+  /** Full, gap-filled timeline so every sub-period is a bar (missing → 0). */
+  const slots = $derived.by(() => {
+    const p = period;
+    const bucketMs = p.bucketSeconds * 1000;
+    const byTs = new Map<number, { consumed: number; produced: number }>();
+    for (const b of summary?.buckets ?? []) {
+      byTs.set(b.timestamp.getTime(), { consumed: b.consumed, produced: b.produced });
+    }
+    const out: { start: Date; consumed: number; produced: number }[] = [];
+    for (let t = p.start.getTime(); t < p.end.getTime() - 1000; t += bucketMs) {
+      const hit = byTs.get(t) ?? { consumed: 0, produced: 0 };
+      out.push({ start: new Date(t), consumed: hit.consumed, produced: hit.produced });
+    }
+    return out;
+  });
+
+  const hasProduction = $derived((summary?.totalProduced ?? 0) > 0.001);
+
+  const axisMax = $derived.by(() => {
+    const m = Math.max(0.001, ...slots.map((s) => Math.max(s.consumed, s.produced)));
+    const step = scope === "day" ? 0.5 : 5;
+    return Math.ceil(m / step) * step || step;
+  });
+
+  const gridSteps = 4;
+
+  const divisor = $derived.by(() => {
+    const p = period;
+    const bucketMs = p.bucketSeconds * 1000;
+    const spanEnd = Math.min(Date.now(), p.end.getTime());
+    const elapsed = Math.max(1, Math.ceil((spanEnd - p.start.getTime()) / bucketMs));
+    const totalSub = Math.round((p.end.getTime() - p.start.getTime()) / bucketMs);
+    return Math.min(elapsed, totalSub || elapsed);
+  });
+
+  const average = $derived((summary?.totalConsumed ?? 0) / Math.max(1, divisor));
+
+  const deltaPct = $derived.by(() => {
+    if (previousTotal == null || previousTotal <= 0 || !summary) return null;
+    return ((summary.totalConsumed - previousTotal) / previousTotal) * 100;
+  });
+
+  // ---- tariff / cost -------------------------------------------------------
+  const TARIFF_KEY = "homeAutomation:energyTariff";
+  let tariff = $state<number>(readTariff());
+  function readTariff(): number {
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(TARIFF_KEY) : null;
+    const v = raw ? parseFloat(raw) : NaN;
+    return Number.isFinite(v) && v > 0 ? v : 0.2016;
+  }
+  function editTariff() {
+    const input = prompt(
+      "Tarif de l'électricité (€ / kWh) :",
+      tariff.toString().replace(".", ","),
+    );
+    if (input == null) return;
+    const v = parseFloat(input.replace(",", "."));
+    if (Number.isFinite(v) && v > 0) {
+      tariff = v;
+      try {
+        localStorage.setItem(TARIFF_KEY, String(v));
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  const cost = $derived((summary?.totalConsumed ?? 0) * tariff);
+
+  // ---- hover tooltip -------------------------------------------------------
+  let hovered = $state<number | null>(null);
+
+  // ---- formatting ----------------------------------------------------------
+  const nf = (v: number, d = 1) =>
+    v.toLocaleString("fr-FR", { minimumFractionDigits: d, maximumFractionDigits: d });
+
+  function power(w: number): string {
+    return Math.abs(w) >= 1000 ? `${nf(w / 1000, 2)} kW` : `${Math.round(w)} W`;
+  }
+
+  function xLabel(i: number): string {
+    const d = slots[i]?.start;
+    if (!d) return "";
+    if (scope === "day") return d.getHours() % 3 === 0 ? `${String(d.getHours()).padStart(2, "0")}h` : "";
+    if (scope === "week") return format(d, "EEE", { locale: fr });
+    const day = d.getDate();
+    return day === 1 || day % 5 === 0 ? String(day) : "";
+  }
+
+  function tipDate(i: number): string {
+    const d = slots[i]?.start;
+    if (!d) return "";
+    if (scope === "day")
+      return `${String(d.getHours()).padStart(2, "0")}h – ${String((d.getHours() + 1) % 24).padStart(2, "0")}h`;
+    return format(d, "EEEE d MMMM", { locale: fr });
+  }
+</script>
+
+<div class="energy-dashboard">
+  <!-- Topbar -->
+  <div class="topbar">
+    <div class="segmented" role="group" aria-label="Période">
+      <button class="seg" class:active={scope === "day"} onclick={() => setScope("day")}>Jour</button>
+      <button class="seg" class:active={scope === "week"} onclick={() => setScope("week")}>Semaine</button>
+      <button class="seg" class:active={scope === "month"} onclick={() => setScope("month")}>Mois</button>
+    </div>
+    <div class="period-nav">
+      <button class="nav-btn" aria-label="Période précédente" onclick={() => (offset -= 1)}>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+      </button>
+      <span class="period-label">{period.label}</span>
+      <button class="nav-btn" aria-label="Période suivante" disabled={atCurrent} onclick={() => (offset += 1)}>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+      </button>
+    </div>
+  </div>
+
+  {#if error}
+    <div class="panel state-panel">
+      <p class="state-msg">{error}</p>
+      <button class="retry" onclick={() => load(period, deviceId)}>Réessayer</button>
+    </div>
+  {:else}
+    <!-- Tiles -->
+    <div class="tiles">
+      <div class="tile hero">
+        <span class="label"><span class="dot consumed"></span>Consommation {scope === "day" ? "du jour" : scope === "week" ? "de la semaine" : "du mois"}</span>
+        <span class="big">{nf(summary?.totalConsumed ?? 0)}<span class="u">kWh</span></span>
+        {#if deltaPct != null}
+          <span class="delta" class:up={deltaPct > 0} class:down={deltaPct <= 0}>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">
+              {#if deltaPct > 0}<polyline points="6 15 12 9 18 15" />{:else}<polyline points="6 9 12 15 18 9" />{/if}
+            </svg>
+            {nf(Math.abs(deltaPct), 0)} %<span class="cmp">vs période précédente</span>
+          </span>
+        {/if}
+      </div>
+
+      <div class="tile">
+        <span class="label">Moyenne / {period.subLabel}</span>
+        <span class="val">{nf(average)}<span class="unit">kWh</span></span>
+        <span class="tile-sub">sur {divisor} {period.subLabel === "heure" ? "h" : "jours"}</span>
+      </div>
+
+      {#if hasProduction}
+        <div class="tile">
+          <span class="label"><span class="dot produced"></span>Production</span>
+          <span class="val">{nf(summary?.totalProduced ?? 0)}<span class="unit">kWh</span></span>
+          {#if (summary?.totalConsumed ?? 0) > 0}
+            <span class="tile-sub prod">{nf(((summary?.totalProduced ?? 0) / (summary?.totalConsumed ?? 1)) * 100, 0)} % de la conso</span>
+          {/if}
+        </div>
+      {/if}
+
+      <div class="tile">
+        <span class="label">Pic de puissance</span>
+        <span class="val">{power(summary?.peakPower ?? 0)}</span>
+        <span class="tile-sub">
+          {#if summary?.peakPowerTimestamp}
+            {format(summary.peakPowerTimestamp, scope === "day" ? "HH'h'mm" : "d MMM, HH'h'mm", { locale: fr })}
+          {:else}—{/if}
+        </span>
+      </div>
+
+      <button class="tile tile-btn" onclick={editTariff} title="Cliquer pour modifier le tarif">
+        <span class="label">Coût estimé</span>
+        <span class="val">≈ {nf(cost, cost >= 100 ? 0 : 2)}<span class="unit">€</span></span>
+        <span class="tile-sub">tarif {nf(tariff, 2).replace(".", ",")} €/kWh · modifier</span>
+      </button>
+    </div>
+
+    <!-- Chart -->
+    <div class="panel">
+      <div class="panel-head">
+        <h2 class="panel-title">Consommation par {period.subLabel}</h2>
+        {#if hasProduction}
+          <div class="legend">
+            <span><span class="sw consumed"></span>Consommée</span>
+            <span><span class="sw produced"></span>Produite</span>
+          </div>
+        {/if}
+      </div>
+      <div class="chart-wrap" class:loading>
+        <div class="chart">
+          <div class="gridlines">
+            {#each Array(gridSteps + 1) as _, g}
+              <div class="gl" style="bottom:{(g / gridSteps) * 100}%">
+                <span class="yl">{nf((axisMax * g) / gridSteps, scope === "day" ? 1 : 0)}</span>
+              </div>
+            {/each}
+          </div>
+
+          {#if hovered != null && slots[hovered]}
+            <div class="tip" style="left:{((hovered + 0.5) / slots.length) * 100}%">
+              <div class="t-date">{tipDate(hovered)}</div>
+              <div class="t-row"><span class="sw consumed"></span>Consommée <b>{nf(slots[hovered].consumed, 2)} kWh</b></div>
+              {#if hasProduction}
+                <div class="t-row"><span class="sw produced"></span>Produite <b>{nf(slots[hovered].produced, 2)} kWh</b></div>
+              {/if}
+            </div>
+          {/if}
+
+          {#each slots as s, i}
+            <div
+              class="col"
+              class:hot={hovered === i}
+              role="presentation"
+              onmouseenter={() => (hovered = i)}
+              onmouseleave={() => (hovered = null)}
+            >
+              <div class="bar consumed" style="height:{(s.consumed / axisMax) * 100}%"></div>
+              {#if hasProduction}
+                <div class="bar produced" style="height:{(s.produced / axisMax) * 100}%"></div>
+              {/if}
+            </div>
+          {/each}
+        </div>
+        <div class="xlabels">
+          {#each slots as _, i}
+            <div class="xl">{xLabel(i)}</div>
+          {/each}
+        </div>
+      </div>
+    </div>
+
+    <!-- Breakdown -->
+    {#if breakdown.length >= 2}
+      {@const bdTotal = breakdown.reduce((a, b) => a + b.consumed, 0)}
+      <div class="panel">
+        <div class="panel-head"><h2 class="panel-title">Répartition par appareil</h2></div>
+        <div class="breakdown-list">
+          {#each breakdown as d}
+            {@const pct = bdTotal > 0 ? (d.consumed / bdTotal) * 100 : 0}
+            <div class="bd-row">
+              <div class="bd-top">
+                <span class="sw" style="background:{d.color}"></span>
+                <span class="nm">{d.name}</span>
+                <span class="kwh">{nf(d.consumed)} kWh</span>
+                <span class="pct">{nf(pct, 0)} %</span>
+              </div>
+              <div class="bd-bar"><div class="bd-fill" style="width:{pct}%;background:{d.color}"></div></div>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .energy-dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  /* Topbar */
+  .topbar {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .segmented {
+    display: inline-flex;
+    background: #f2f4f7;
+    border-radius: 9px;
+    padding: 3px;
+    gap: 2px;
+  }
+  .seg {
+    padding: 0.38rem 0.85rem;
+    border: none;
+    background: transparent;
+    border-radius: 7px;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #667085;
+    cursor: pointer;
+    transition: all 0.15s;
+    font-family: inherit;
+  }
+  .seg:hover {
+    color: #101828;
+  }
+  .seg.active {
+    background: #fff;
+    color: #101828;
+    box-shadow: 0 1px 2px rgba(16, 24, 40, 0.12);
+  }
+  .period-nav {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-left: auto;
+    background: #fff;
+    border: 1px solid var(--color-card-border);
+    border-radius: 9px;
+    padding: 3px;
+    box-shadow: var(--shadow-sm);
+  }
+  .nav-btn {
+    width: 30px;
+    height: 30px;
+    display: grid;
+    place-items: center;
+    border: none;
+    background: transparent;
+    border-radius: 7px;
+    cursor: pointer;
+    color: #667085;
+    transition:
+      background 0.12s,
+      color 0.12s;
+  }
+  .nav-btn:hover:not(:disabled) {
+    background: #f2f4f7;
+    color: #101828;
+  }
+  .nav-btn:disabled {
+    opacity: 0.35;
+    cursor: default;
+  }
+  .period-label {
+    min-width: 128px;
+    text-align: center;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #101828;
+    font-variant-numeric: tabular-nums;
+    text-transform: capitalize;
+  }
+
+  /* Tiles */
+  .tiles {
+    display: grid;
+    grid-template-columns: 1.5fr repeat(3, 1fr);
+    gap: 12px;
+  }
+  .tile {
+    background: var(--color-card-bg);
+    border-radius: 14px;
+    box-shadow: var(--shadow-sm);
+    padding: 1.05rem 1.15rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    min-width: 0;
+    text-align: left;
+  }
+  .tile-btn {
+    border: none;
+    font-family: inherit;
+    cursor: pointer;
+    transition: box-shadow 0.15s;
+  }
+  .tile-btn:hover {
+    box-shadow: var(--shadow-md);
+  }
+  .label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #667085;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 3px;
+    flex-shrink: 0;
+  }
+  .dot.consumed,
+  .sw.consumed {
+    background: #3b82f6;
+  }
+  .dot.produced,
+  .sw.produced {
+    background: #16a34a;
+  }
+  .val {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #101828;
+    font-variant-numeric: tabular-nums;
+    display: flex;
+    align-items: baseline;
+    gap: 0.3rem;
+  }
+  .unit {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #98a2b3;
+  }
+  .tile-sub {
+    font-size: 0.75rem;
+    color: #98a2b3;
+  }
+  .tile-sub.prod {
+    color: #16a34a;
+    font-weight: 600;
+  }
+  .tile.hero {
+    padding: 1.2rem 1.3rem;
+  }
+  .hero .big {
+    font-size: 2.6rem;
+    line-height: 1;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    font-variant-numeric: tabular-nums;
+    color: #101828;
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+  }
+  .hero .big .u {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #98a2b3;
+  }
+  .delta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    width: fit-content;
+  }
+  .delta.up {
+    background: #fef2f2;
+    color: #dc2626;
+  }
+  .delta.down {
+    background: #ecfdf3;
+    color: #16a34a;
+  }
+  .delta .cmp {
+    color: #98a2b3;
+    font-weight: 500;
+  }
+
+  /* Panel */
+  .panel {
+    background: var(--color-card-bg);
+    border-radius: 14px;
+    box-shadow: var(--shadow-sm);
+    overflow: hidden;
+  }
+  .panel-head {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.9rem 1.15rem;
+    border-bottom: 1px solid #f1f3f5;
+  }
+  .panel-title {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: #101828;
+    margin: 0;
+  }
+  .legend {
+    display: inline-flex;
+    gap: 0.9rem;
+    margin-left: auto;
+  }
+  .legend span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.78rem;
+    color: #667085;
+    font-weight: 500;
+  }
+  .sw {
+    width: 11px;
+    height: 11px;
+    border-radius: 3px;
+  }
+
+  /* Chart */
+  .chart-wrap {
+    padding: 1.1rem 1.15rem 1.3rem;
+    transition: opacity 0.15s;
+  }
+  .chart-wrap.loading {
+    opacity: 0.45;
+  }
+  .chart {
+    position: relative;
+    height: 240px;
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    padding-left: 34px;
+    border-bottom: 1px solid var(--color-card-border);
+  }
+  .gridlines {
+    position: absolute;
+    left: 34px;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    pointer-events: none;
+  }
+  .gl {
+    position: absolute;
+    left: 0;
+    right: 0;
+    border-top: 1px dashed #eef0f3;
+  }
+  .yl {
+    position: absolute;
+    left: -34px;
+    top: -8px;
+    font-size: 0.68rem;
+    color: #98a2b3;
+    font-variant-numeric: tabular-nums;
+    width: 30px;
+    text-align: right;
+  }
+  .col {
+    position: relative;
+    flex: 1;
+    height: 100%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 2px;
+    cursor: pointer;
+    min-width: 0;
+  }
+  .bar {
+    width: 100%;
+    max-width: 26px;
+    border-radius: 4px 4px 0 0;
+    transition: opacity 0.12s;
+  }
+  .bar.consumed {
+    background: #3b82f6;
+  }
+  .bar.produced {
+    background: #16a34a;
+  }
+  .col.hot .bar {
+    opacity: 0.78;
+  }
+  .xlabels {
+    display: flex;
+    gap: 2px;
+    padding-left: 34px;
+    margin-top: 0.5rem;
+  }
+  .xl {
+    flex: 1;
+    text-align: center;
+    font-size: 0.68rem;
+    color: #98a2b3;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  .tip {
+    position: absolute;
+    top: -6px;
+    transform: translate(-50%, -100%);
+    background: #101828;
+    color: #fff;
+    padding: 0.5rem 0.65rem;
+    border-radius: 8px;
+    font-size: 0.75rem;
+    line-height: 1.5;
+    pointer-events: none;
+    white-space: nowrap;
+    z-index: 5;
+    box-shadow: 0 6px 16px rgba(16, 24, 40, 0.22);
+  }
+  .t-date {
+    color: #cbd5e1;
+    font-size: 0.68rem;
+    margin-bottom: 2px;
+    text-transform: capitalize;
+  }
+  .t-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .t-row .sw {
+    width: 8px;
+    height: 8px;
+    border-radius: 2px;
+  }
+  .tip b {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Breakdown */
+  .breakdown-list {
+    padding: 1rem 1.15rem 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+  .bd-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .bd-top {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+  }
+  .bd-top .nm {
+    color: #475467;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .bd-top .kwh {
+    margin-left: auto;
+    font-weight: 700;
+    color: #101828;
+    font-variant-numeric: tabular-nums;
+  }
+  .bd-top .pct {
+    color: #98a2b3;
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+    width: 40px;
+    text-align: right;
+  }
+  .bd-bar {
+    height: 8px;
+    border-radius: 999px;
+    background: #f0f2f5;
+    overflow: hidden;
+  }
+  .bd-fill {
+    height: 100%;
+    border-radius: 999px;
+  }
+
+  /* States */
+  .state-panel {
+    padding: 2rem 1.15rem;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.85rem;
+  }
+  .state-msg {
+    margin: 0;
+    color: #667085;
+    font-size: 0.9rem;
+  }
+  .retry {
+    padding: 0.5rem 1.1rem;
+    border: 1px solid var(--color-card-border);
+    background: #fff;
+    border-radius: 8px;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #101828;
+    cursor: pointer;
+  }
+  .retry:hover {
+    background: #f7f8fa;
+  }
+
+  @media (max-width: 760px) {
+    .tiles {
+      grid-template-columns: 1fr 1fr;
+    }
+    .tile.hero {
+      grid-column: 1 / -1;
+    }
+    .legend {
+      width: 100%;
+      margin: 0.4rem 0 0;
+    }
+    .panel-head {
+      flex-wrap: wrap;
+    }
+  }
+</style>

--- a/frontend/src/lib/explorer/CategoryRail.svelte
+++ b/frontend/src/lib/explorer/CategoryRail.svelte
@@ -37,6 +37,27 @@
     return selectedKeys.has(seriesKey(deviceId, metric));
   }
 
+  function allSelected(list: { device_id: string }[], metric: ExplorerMetric) {
+    return list.length > 0 && list.every((d) => isSelected(d.device_id, metric));
+  }
+
+  function toggleAll(
+    list: { device_id: string; color: string | null }[],
+    metric: ExplorerMetric,
+    event: MouseEvent,
+  ) {
+    // Don't let the click bubble to the header (which expands/collapses).
+    event.stopPropagation();
+    if (allSelected(list, metric)) {
+      explorerConfig.clearCategory(metric);
+    } else {
+      explorerConfig.selectCategory(
+        metric,
+        list.map((d) => ({ deviceId: d.device_id, color: d.color })),
+      );
+    }
+  }
+
   function latestLabel(deviceId: string, metric: ExplorerMetric): string | null {
     const reading = latestByDevice[deviceId] as SensorReading | null | undefined;
     if (!reading) return null;
@@ -55,22 +76,43 @@
     {@const isOpen = open.has(cat.id)}
     {@const list = devicesForCategory(devices, cat.id)}
     <section class="section" class:open={isOpen} class:first={i === 0}>
-      <button
-        class="head"
-        aria-expanded={isOpen}
-        onclick={() => toggleSection(cat.id)}
-      >
-        <svg class="icon" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
-          <path d={cat.iconPath} />
-        </svg>
-        <span class="title">{cat.label}</span>
-        {#if countByCategory[cat.id]}
-          <span class="badge">{countByCategory[cat.id]}</span>
+      <div class="head">
+        <button
+          class="head-toggle"
+          aria-expanded={isOpen}
+          onclick={() => toggleSection(cat.id)}
+        >
+          <svg class="icon" viewBox="0 0 24 24" width="18" height="18" fill="currentColor" aria-hidden="true">
+            <path d={cat.iconPath} />
+          </svg>
+          <span class="title">{cat.label}</span>
+          {#if countByCategory[cat.id]}
+            <span class="badge">{countByCategory[cat.id]}</span>
+          {/if}
+        </button>
+        {#if list.length > 0}
+          <button
+            class="select-all"
+            class:on={allSelected(list, cat.id)}
+            onclick={(e) => toggleAll(list, cat.id, e)}
+            title={allSelected(list, cat.id)
+              ? "Tout désélectionner"
+              : "Tout sélectionner"}
+          >
+            {allSelected(list, cat.id) ? "Aucun" : "Tout"}
+          </button>
         {/if}
-        <svg class="chevron" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <polyline points="6 9 12 15 18 9" />
-        </svg>
-      </button>
+        <button
+          class="chev-btn"
+          aria-label={isOpen ? "Replier" : "Déplier"}
+          aria-expanded={isOpen}
+          onclick={() => toggleSection(cat.id)}
+        >
+          <svg class="chevron" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+      </div>
 
       {#if isOpen}
         <div class="body" transition:slide={{ duration: 180 }}>
@@ -128,9 +170,15 @@
   .head {
     display: flex;
     align-items: center;
+  }
+
+  .head-toggle {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
     gap: 0.625rem;
-    width: 100%;
-    padding: 0.875rem 1rem;
+    padding: 0.875rem 0.5rem 0.875rem 1rem;
     background: transparent;
     border: none;
     cursor: pointer;
@@ -141,12 +189,46 @@
     transition: color 0.15s;
   }
 
-  .head:hover {
+  .head-toggle:hover {
     color: #101828;
   }
 
-  .section.open .head {
+  .section.open .head-toggle {
     color: #101828;
+  }
+
+  .select-all {
+    flex-shrink: 0;
+    padding: 0.2rem 0.55rem;
+    border: 1px solid #e4e7ec;
+    background: #fff;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #667085;
+    cursor: pointer;
+    transition: all 0.12s;
+  }
+
+  .select-all:hover {
+    border-color: #b2ccff;
+    color: #1d4ed8;
+  }
+
+  .select-all.on {
+    background: #eff6ff;
+    border-color: #bfdbfe;
+    color: #1d4ed8;
+  }
+
+  .chev-btn {
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    padding: 0.875rem 1rem 0.875rem 0.5rem;
+    background: transparent;
+    border: none;
+    cursor: pointer;
   }
 
   .icon {

--- a/frontend/src/lib/explorer/explorerStore.ts
+++ b/frontend/src/lib/explorer/explorerStore.ts
@@ -87,6 +87,43 @@ function createExplorerConfig() {
       });
     },
 
+    /** Add every given (device, metric) series that isn't already selected. */
+    selectCategory(
+      metric: ExplorerMetric,
+      entries: { deviceId: string; color?: string | null }[],
+    ) {
+      update((state) => {
+        let series = state.series;
+        for (const entry of entries) {
+          const key = seriesKey(entry.deviceId, metric);
+          if (series.some((s) => seriesKey(s.deviceId, s.metric) === key)) continue;
+          series = [
+            ...series,
+            {
+              deviceId: entry.deviceId,
+              metric,
+              color: nextColor({ ...state, series }, entry.color),
+            },
+          ];
+        }
+        const next = { ...state, series };
+        persist(next);
+        return next;
+      });
+    },
+
+    /** Remove every selected series of a metric (a whole category). */
+    clearCategory(metric: ExplorerMetric) {
+      update((state) => {
+        const next = {
+          ...state,
+          series: state.series.filter((s) => s.metric !== metric),
+        };
+        persist(next);
+        return next;
+      });
+    },
+
     removeSeries(deviceId: string, metric: ExplorerMetric) {
       update((state) => {
         const key = seriesKey(deviceId, metric);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,8 +2,19 @@ import { mount } from 'svelte'
 import './app.css'
 import App from './App.svelte'
 
-const app = mount(App, {
-  target: document.getElementById('app')!,
-})
+// Demo builds (VITE_MOCK_BUILD=1, see `npm run build:demo`) have no backend, so
+// install the in-browser mock before anything can issue a request. The env flag
+// is a compile-time constant, so a normal production build dead-code-eliminates
+// this branch and never bundles the mock.
+async function bootstrap() {
+  if (import.meta.env.VITE_MOCK_BUILD) {
+    const { installMockBackend } = await import('../mock/browser')
+    installMockBackend()
+  }
 
-export default app
+  return mount(App, {
+    target: document.getElementById('app')!,
+  })
+}
+
+export default bootstrap()

--- a/frontend/src/routes/ConsommationsView.svelte
+++ b/frontend/src/routes/ConsommationsView.svelte
@@ -1,85 +1,11 @@
 <script lang="ts">
-  import UnifiedGraphPanel from "../lib/graphs/UnifiedGraphPanel.svelte";
-  import EnergyListPanel from "../lib/devices/EnergyListPanel.svelte";
-  import PageState from "../lib/shared/PageState.svelte";
-  import type { DeviceInfo } from "../lib/api/devices";
-  import { deviceStateMemory, sensorsMemory } from "../lib/memory";
-  import { graphConfig } from "../lib/stores/graphConfig";
-  import { onMount } from "svelte";
-
-  let loading = $state(true);
-  let error = $state<string | null>(null);
-  let initialized = $state(false);
-
-  // Filter: only energy meters for this view
-  const isEnergyMeter = (device: DeviceInfo) =>
-    device.capabilities.some(
-      (cap) => cap.type === "sensor" && cap.sensor_type === "energy_meter"
-    );
-
-  // Initialize graphConfig with only energy meters
-  function initializeGraphConfig(devices: DeviceInfo[]) {
-    const energyMeters = devices
-      .filter(isEnergyMeter)
-      .map((s) => ({ deviceId: s.device_id, color: s.color }));
-    graphConfig.initializeSensors(energyMeters);
-  }
-
-  async function loadData(force = false) {
-    const sensorState = $sensorsMemory;
-
-    if (!force && sensorState.devicesLoaded) {
-      initializeGraphConfig(sensorState.devices);
-      if (!initialized) {
-        graphConfig.hideAll();
-        initialized = true;
-      }
-      loading = false;
-      return;
-    }
-
-    loading = true;
-    error = null;
-
-    try {
-      const sensors = await sensorsMemory.ensureDevices(force);
-
-      // Always initialize graphConfig for this view
-      initializeGraphConfig(sensors);
-      if (!initialized) {
-        graphConfig.hideAll();
-        initialized = true;
-      }
-      void deviceStateMemory.ensureDeviceStates(force).catch((err) => {
-        console.error("Failed to fetch device states:", err);
-      });
-    } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to load energy data";
-    } finally {
-      loading = false;
-    }
-  }
-
-  function retryLoad() {
-    void loadData(true);
-  }
-
-  onMount(() => {
-    void loadData();
-  });
+  import EnergyDashboard from "../lib/devices/EnergyDashboard.svelte";
 </script>
 
 <div class="consommations-view">
-  <PageState {loading} {error} loadingText="Loading energy meters..." onRetry={retryLoad}>
-    <div class="unified-layout">
-      <div class="graph-section">
-        <UnifiedGraphPanel metricType="power" />
-      </div>
-      <div class="meters-section">
-        <EnergyListPanel />
-      </div>
-    </div>
-  </PageState>
+  <div class="board">
+    <EnergyDashboard />
+  </div>
 </div>
 
 <style>
@@ -88,31 +14,21 @@
     height: 100%;
   }
 
-  .unified-layout {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-    height: 100%;
-  }
-
-  .graph-section {
-    flex: 0 0 auto;
-  }
-
-  .meters-section {
-    flex: 1;
-    min-height: 0;
+  /* The gray "board" matches the sensor explorer: content sits on it as white
+     panels with a tight gutter, so the energy page reads as part of the site. */
+  .board {
+    padding: 1.25rem;
+    background: #eef1f5;
+    border-radius: 18px;
+    margin: 1.25rem;
+    min-height: calc(100vh - var(--app-header-height, 88px) - 2.5rem);
   }
 
   @media (max-width: 768px) {
-    .unified-layout {
-      gap: var(--section-gap, 1.5rem);
-    }
-  }
-
-  @media (max-width: 480px) {
-    .unified-layout {
-      gap: var(--section-gap, 1rem);
+    .board {
+      padding: 0.75rem;
+      margin: 0.75rem;
+      border-radius: 14px;
     }
   }
 </style>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,8 +7,18 @@ import { mockBackend } from './mock/plugin';
 // instead of proxying to the Rust server on :8080.
 const useMock = !!process.env.VITE_MOCK;
 
+// Set VITE_MOCK_BUILD=1 (see `npm run build:demo`) to produce a static, backend-
+// less bundle for the online demo: the in-browser mock (mock/browser.ts) is
+// pulled in at runtime and the assets are served under a GitHub Pages base path.
+const demoBuild = !!process.env.VITE_MOCK_BUILD;
+// GitHub Pages serves a project site under /<repo>/. Override with VITE_BASE if
+// hosting elsewhere (e.g. a custom domain or a different repo name).
+const base = demoBuild ? process.env.VITE_BASE ?? '/home-automation-rs/' : '/';
+
 // https://vite.dev/config/
 export default defineConfig({
+  base,
+
   plugins: [
     svelte(),
     checker({
@@ -21,7 +31,8 @@ export default defineConfig({
   ],
 
   build: {
-    outDir: '../static',
+    // Keep the demo bundle out of ../static (the bundle the Rust server ships).
+    outDir: demoBuild ? 'dist-demo' : '../static',
     emptyOutDir: true,
     target: 'es2020',
     minify: 'terser',

--- a/src/db/queries/energy.rs
+++ b/src/db/queries/energy.rs
@@ -1,0 +1,231 @@
+//! Cumulative-energy summaries for the energy dashboard.
+//!
+//! The meter reports `energy`/`produced_energy` as **monotonic lifetime
+//! counters** (kWh since the meter was commissioned), so "how much did we use
+//! this day/month?" is a *delta* of the counter, not an average of it (the
+//! generic `AVG`-based aggregation in [`super::sensor`] is meaningless for a
+//! counter). This module computes those deltas per time bucket.
+//!
+//! Method, per device:
+//! 1. Take the **last** counter sample in each bucket (window `ROW_NUMBER`).
+//! 2. Take an **anchor** — the last counter sample strictly before the range.
+//! 3. Difference consecutive bucket values (anchor → bucket 0 → bucket 1 → …),
+//!    clamping negatives to zero so a counter reset can't produce a bogus
+//!    negative bucket.
+//!
+//! Because the buckets telescope, the reported `total_consumed` is exactly the
+//! sum of the per-bucket deltas — the histogram and the hero total always agree.
+
+use std::collections::BTreeMap;
+
+use crate::models::{EnergyBucket, EnergySummary};
+use rusqlite::{Result, ToSql};
+use tracing::{debug, info, warn};
+
+use super::super::connection::{Database, MutexExt};
+
+/// (bucket_ts, energy_counter, produced_counter) for a single device.
+type BucketRow = (i64, f64, f64);
+
+impl Database {
+    /// Compute a cumulative-energy summary for a period.
+    ///
+    /// `device_id = None` aggregates across every energy meter (per-device
+    /// deltas summed per bucket). `peak_power` is the single highest power
+    /// sample in the range (across meters when unfiltered).
+    pub fn get_energy_summary(
+        &self,
+        device_id: Option<&str>,
+        start_timestamp: i64,
+        end_timestamp: i64,
+        bucket_seconds: i64,
+    ) -> Result<EnergySummary> {
+        let bucket = bucket_seconds.max(1);
+        debug!(
+            device_id = ?device_id,
+            start = start_timestamp,
+            end = end_timestamp,
+            bucket_seconds = bucket,
+            "Computing energy summary"
+        );
+        let started = std::time::Instant::now();
+
+        // Owned copy so borrows in the dynamic param vectors outlive each query.
+        let dev = device_id.map(str::to_string);
+
+        let conn = self.conn.lock_or_recover();
+
+        // --- 1. Last counter value per (device, bucket) within the range ------
+        let bucket_filter = if dev.is_some() {
+            " AND device_id = ?4"
+        } else {
+            ""
+        };
+        // Buckets are aligned to `start` (not the epoch) so the caller controls
+        // the boundaries — the frontend passes local midnight / 1st-of-month, and
+        // the bars line up with local days regardless of timezone.
+        let bucket_sql = format!(
+            "SELECT device_id, bucket_ts, energy, produced_energy
+             FROM (
+                 SELECT device_id,
+                        ((timestamp - ?2) / ?1) * ?1 + ?2 AS bucket_ts,
+                        energy, produced_energy,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY device_id, ((timestamp - ?2) / ?1) * ?1 + ?2
+                            ORDER BY timestamp DESC, rowid DESC
+                        ) AS rn
+                 FROM energy_readings
+                 WHERE timestamp >= ?2 AND timestamp <= ?3{bucket_filter}
+             )
+             WHERE rn = 1
+             ORDER BY device_id, bucket_ts"
+        );
+        let mut bucket_params: Vec<&dyn ToSql> =
+            vec![&bucket, &start_timestamp, &end_timestamp];
+        if let Some(ref d) = dev {
+            bucket_params.push(d);
+        }
+
+        let mut stmt = conn.prepare(&bucket_sql)?;
+        let rows = stmt
+            .query_map(bucket_params.as_slice(), |row| {
+                let device: String = row.get(0)?;
+                Ok((device, (row.get::<_, i64>(1)?, row.get::<_, f64>(2)?, row.get::<_, f64>(3)?)))
+            })?
+            .collect::<Result<Vec<(String, BucketRow)>>>()?;
+
+        // --- 2. Anchor: last counter value strictly before `start` -----------
+        let anchor_filter = if dev.is_some() {
+            " AND device_id = ?2"
+        } else {
+            ""
+        };
+        let anchor_sql = format!(
+            "SELECT device_id, energy, produced_energy
+             FROM (
+                 SELECT device_id, energy, produced_energy,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY device_id
+                            ORDER BY timestamp DESC, rowid DESC
+                        ) AS rn
+                 FROM energy_readings
+                 WHERE timestamp < ?1{anchor_filter}
+             )
+             WHERE rn = 1"
+        );
+        let mut anchor_params: Vec<&dyn ToSql> = vec![&start_timestamp];
+        if let Some(ref d) = dev {
+            anchor_params.push(d);
+        }
+        let mut stmt = conn.prepare(&anchor_sql)?;
+        let anchors: std::collections::HashMap<String, (f64, f64)> = stmt
+            .query_map(anchor_params.as_slice(), |row| {
+                Ok((row.get::<_, String>(0)?, (row.get::<_, f64>(1)?, row.get::<_, f64>(2)?)))
+            })?
+            .collect::<Result<_>>()?;
+
+        // --- 3. Peak instantaneous power over the range ----------------------
+        let peak_filter = if dev.is_some() {
+            " AND device_id = ?3"
+        } else {
+            ""
+        };
+        let peak_sql = format!(
+            "SELECT timestamp, power
+             FROM energy_readings
+             WHERE timestamp >= ?1 AND timestamp <= ?2{peak_filter}
+             ORDER BY power DESC, timestamp ASC
+             LIMIT 1"
+        );
+        let mut peak_params: Vec<&dyn ToSql> = vec![&start_timestamp, &end_timestamp];
+        if let Some(ref d) = dev {
+            peak_params.push(d);
+        }
+        let mut stmt = conn.prepare(&peak_sql)?;
+        let peak: Option<(i64, f64)> = stmt
+            .query_row(peak_params.as_slice(), |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?))
+            })
+            .ok();
+
+        drop(stmt);
+
+        // --- 4. Difference consecutive counter values, per device ------------
+        // Rows are ordered by (device_id, bucket_ts); walk each device's run and
+        // accumulate deltas into a shared per-bucket map so multiple meters sum.
+        let mut agg: BTreeMap<i64, (f64, f64)> = BTreeMap::new();
+        let mut cur_device: Option<&str> = None;
+        let mut prev_energy: Option<f64> = None;
+        let mut prev_produced: Option<f64> = None;
+
+        for (device, (bucket_ts, energy, produced)) in &rows {
+            if cur_device != Some(device.as_str()) {
+                // New device run: seed from its anchor (None if no prior data).
+                cur_device = Some(device.as_str());
+                match anchors.get(device) {
+                    Some((e, p)) => {
+                        prev_energy = Some(*e);
+                        prev_produced = Some(*p);
+                    }
+                    None => {
+                        prev_energy = None;
+                        prev_produced = None;
+                    }
+                }
+            }
+
+            let entry = agg.entry(*bucket_ts).or_insert((0.0, 0.0));
+            if let Some(pe) = prev_energy {
+                entry.0 += (energy - pe).max(0.0);
+            }
+            if let Some(pp) = prev_produced {
+                entry.1 += (produced - pp).max(0.0);
+            }
+            prev_energy = Some(*energy);
+            prev_produced = Some(*produced);
+        }
+
+        let buckets: Vec<EnergyBucket> = agg
+            .into_iter()
+            .map(|(timestamp, (consumed, produced))| EnergyBucket {
+                timestamp,
+                consumed,
+                produced,
+            })
+            .collect();
+
+        let total_consumed = buckets.iter().map(|b| b.consumed).sum();
+        let total_produced = buckets.iter().map(|b| b.produced).sum();
+
+        let summary = EnergySummary {
+            start: start_timestamp,
+            end: end_timestamp,
+            bucket_seconds: bucket,
+            total_consumed,
+            total_produced,
+            peak_power: peak.map(|(_, p)| p).unwrap_or(0.0),
+            peak_power_timestamp: peak.map(|(ts, _)| ts),
+            buckets,
+        };
+
+        let elapsed = started.elapsed();
+        info!(
+            device_id = ?device_id,
+            bucket_count = summary.buckets.len(),
+            total_consumed = summary.total_consumed,
+            total_produced = summary.total_produced,
+            duration_ms = elapsed.as_millis(),
+            "Computed energy summary"
+        );
+        if summary.buckets.is_empty() {
+            warn!(
+                device_id = ?device_id,
+                start = start_timestamp,
+                end = end_timestamp,
+                "No energy readings for summary range"
+            );
+        }
+
+        Ok(summary)
+    }
+}

--- a/src/db/queries/mod.rs
+++ b/src/db/queries/mod.rs
@@ -1,6 +1,7 @@
 // Query modules organized by domain
 pub mod automation;
 pub mod device;
+pub mod energy;
 pub mod device_position;
 pub mod device_state;
 pub mod floor_plan;

--- a/src/db/tests.rs
+++ b/src/db/tests.rs
@@ -2029,4 +2029,87 @@ mod tests {
         let retrieved = db.get_floor_plan().unwrap().unwrap();
         assert_eq!(retrieved.svg_content, large_svg);
     }
+
+    // ==================== Energy Summary (delta) Tests ====================
+
+    /// Insert an energy reading with an explicit unix timestamp and counters.
+    fn insert_energy_at(db: &Database, device_id: &str, ts: i64, power: f32, energy: f32) {
+        let reading = SensorReading::EnergyMeter {
+            device_id: device_id.to_string(),
+            power,
+            energy,
+            produced_energy: 0.0,
+            voltage: 230.0,
+            current: 6.5,
+            ac_frequency: 50.0,
+            power_factor: 0.98,
+            timestamp: chrono::DateTime::from_timestamp(ts, 0).unwrap(),
+        };
+        db.insert_reading(&reading).unwrap();
+    }
+
+    #[test]
+    fn test_energy_summary_deltas_and_totals() {
+        let (db, _temp_dir) = create_test_db();
+        insert_test_device(&db, "em1", SensorType::EnergyMeter);
+
+        // Anchor strictly before the range: counter at 100 kWh.
+        insert_energy_at(&db, "em1", 3599, 800.0, 100.0);
+        // Bucket [3600, 7200): last sample counter = 102.
+        insert_energy_at(&db, "em1", 3600, 1000.0, 100.0);
+        insert_energy_at(&db, "em1", 7100, 1200.0, 102.0);
+        // Bucket [7200, 10800): last sample counter = 105, and the peak power.
+        insert_energy_at(&db, "em1", 7200, 1500.0, 102.0);
+        insert_energy_at(&db, "em1", 10000, 1400.0, 105.0);
+        // Bucket [10800, 14400): flat counter (no consumption).
+        insert_energy_at(&db, "em1", 10800, 300.0, 105.0);
+        insert_energy_at(&db, "em1", 14000, 300.0, 105.0);
+
+        let summary = db
+            .get_energy_summary(Some("em1"), 3600, 14400, 3600)
+            .unwrap();
+
+        assert_eq!(summary.buckets.len(), 3);
+        // Deltas: anchor 100 -> 102 -> 105 -> 105.
+        assert!((summary.buckets[0].consumed - 2.0).abs() < 1e-6);
+        assert!((summary.buckets[1].consumed - 3.0).abs() < 1e-6);
+        assert!((summary.buckets[2].consumed - 0.0).abs() < 1e-6);
+        assert_eq!(summary.buckets[0].timestamp, 3600);
+        assert_eq!(summary.buckets[1].timestamp, 7200);
+        assert_eq!(summary.buckets[2].timestamp, 10800);
+
+        // Total == counter delta across the range (105 - 100).
+        assert!((summary.total_consumed - 5.0).abs() < 1e-6);
+        assert!((summary.total_produced - 0.0).abs() < 1e-6);
+
+        // Peak power sample and its timestamp.
+        assert!((summary.peak_power - 1500.0).abs() < 1e-6);
+        assert_eq!(summary.peak_power_timestamp, Some(7200));
+
+        // Aggregating over all meters (no filter) matches the single meter here.
+        let all = db.get_energy_summary(None, 3600, 14400, 3600).unwrap();
+        assert!((all.total_consumed - 5.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_energy_summary_no_anchor_seeds_from_first_bucket() {
+        let (db, _temp_dir) = create_test_db();
+        insert_test_device(&db, "em2", SensorType::EnergyMeter);
+
+        // No reading before `start`, so bucket 0 has no baseline and reports 0;
+        // subsequent buckets diff normally.
+        insert_energy_at(&db, "em2", 3600, 500.0, 50.0);
+        insert_energy_at(&db, "em2", 7200, 500.0, 54.0);
+        insert_energy_at(&db, "em2", 10800, 500.0, 60.0);
+
+        let summary = db
+            .get_energy_summary(Some("em2"), 3600, 14400, 3600)
+            .unwrap();
+
+        assert_eq!(summary.buckets.len(), 3);
+        assert!((summary.buckets[0].consumed - 0.0).abs() < 1e-6);
+        assert!((summary.buckets[1].consumed - 4.0).abs() < 1e-6);
+        assert!((summary.buckets[2].consumed - 6.0).abs() < 1e-6);
+        assert!((summary.total_consumed - 10.0).abs() < 1e-6);
+    }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -176,6 +176,10 @@ async fn handle_request(
             debug!(query = ?query, "Serving readings");
             routes::serve_readings(&db, query.as_deref())
         }),
+        ("GET", "/api/energy/summary") => Ok({
+            debug!(query = ?query, "Serving energy summary");
+            routes::serve_energy_summary(&db, query.as_deref())
+        }),
         ("GET", "/api/devices/switches") => Ok({
             debug!("Serving switches list");
             routes::serve_switches_list(&db, &switch_state, &device_state)

--- a/src/http/routes/mod.rs
+++ b/src/http/routes/mod.rs
@@ -18,7 +18,7 @@ pub use automation::{
 pub use floor_plan::{delete_floor_plan, serve_floor_plan, upload_floor_plan};
 pub use logs::{serve_log_since, serve_log_view, serve_logs_list, serve_process_history};
 pub use positions::{serve_device_positions, update_device_position};
-pub use sensors::{serve_readings, serve_sensors};
+pub use sensors::{serve_energy_summary, serve_readings, serve_sensors};
 pub use switches::{
     execute_command, permit_join, serve_device_state, serve_device_states, serve_switches_list,
     set_device_option, update_device,

--- a/src/http/routes/sensors.rs
+++ b/src/http/routes/sensors.rs
@@ -189,3 +189,49 @@ pub fn serve_readings(db: &Database, query: Option<&str>) -> Response<Full<Bytes
         }
     }
 }
+
+/// Serve a cumulative-energy summary (`GET /api/energy/summary`).
+///
+/// Unlike `/api/readings`, which averages the raw counter (meaningless for a
+/// monotonic meter), this returns per-bucket **deltas** plus the period totals
+/// and peak power — the data the energy dashboard needs. Query params:
+/// `device_id` (optional, aggregate over all meters when absent), `start`,
+/// `end` (unix seconds), `bucket` (bucket size in seconds).
+pub fn serve_energy_summary(db: &Database, query: Option<&str>) -> Response<Full<Bytes>> {
+    let params = QueryParams::new(query);
+    let device_id = params.get("device_id");
+
+    let end_ts = params
+        .get_optional_i64("end")
+        .unwrap_or_else(|| chrono::Utc::now().timestamp());
+    let start_ts = params.get_optional_i64("start").unwrap_or_else(|| {
+        let hours = params.get_i64("hours", 24);
+        end_ts - (hours * 3600)
+    });
+
+    if start_ts >= end_ts {
+        return bad_request_response("`start` must be before `end`");
+    }
+
+    // Default to daily buckets when unspecified.
+    let bucket_seconds = params.get_optional_i64("bucket").unwrap_or(86_400).max(1);
+
+    info!(
+        device_id = ?device_id,
+        start = start_ts,
+        end = end_ts,
+        bucket_seconds,
+        "Serving energy summary"
+    );
+
+    match db.get_energy_summary(device_id, start_ts, end_ts, bucket_seconds) {
+        Ok(summary) => match serialize_to_json(&summary, "energy summary") {
+            Ok(json) => json_response(json),
+            Err(response) => *response,
+        },
+        Err(e) => {
+            error!(error = %e, device_id = ?device_id, "Database error while computing energy summary");
+            internal_error_response("Database error")
+        }
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -13,5 +13,6 @@ pub use device::{
     NetworkEdge, NetworkTopology, PowerSource, SensorType,
 };
 pub use mqtt::{
-    DeviceMqttMessage, SensorReading, SwitchCommand, SwitchCommandMessage, SwitchState,
+    DeviceMqttMessage, EnergyBucket, EnergySummary, SensorReading, SwitchCommand,
+    SwitchCommandMessage, SwitchState,
 };

--- a/src/models/mqtt.rs
+++ b/src/models/mqtt.rs
@@ -344,6 +344,39 @@ pub enum SensorReading {
     },
 }
 
+/// One time-bucket of energy consumption/production.
+///
+/// Because the meter exposes `energy`/`produced_energy` as *cumulative* lifetime
+/// counters, the per-bucket figures here are **deltas** (difference of the
+/// counter across the bucket), not raw counter values.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct EnergyBucket {
+    /// Bucket start, unix seconds (aligned to `bucket_seconds`).
+    pub timestamp: i64,
+    /// kWh consumed during the bucket.
+    pub consumed: f64,
+    /// kWh produced during the bucket.
+    pub produced: f64,
+}
+
+/// Aggregated cumulative-energy summary for a period, used by the energy
+/// dashboard (hero total + per-bucket histogram + peak power).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct EnergySummary {
+    pub start: i64,
+    pub end: i64,
+    pub bucket_seconds: i64,
+    /// Total kWh consumed over the period (== sum of `buckets[].consumed`).
+    pub total_consumed: f64,
+    /// Total kWh produced over the period (== sum of `buckets[].produced`).
+    pub total_produced: f64,
+    /// Peak instantaneous power seen over the period (W); highest single sample.
+    pub peak_power: f64,
+    /// Timestamp (unix seconds) of the peak-power sample, if any data exists.
+    pub peak_power_timestamp: Option<i64>,
+    pub buckets: Vec<EnergyBucket>,
+}
+
 impl SensorReading {
     /// Create a sensor reading from MQTT message
     pub fn from_mqtt(


### PR DESCRIPTION
## Résumé

Refonte de la page Énergie autour de l'**énergie cumulée** (jour / semaine / mois) et passage des écrans énergie au **thème clair** du site (fini la page détail sombre qui faisait tache).

### Backend
- `GET /api/energy/summary?device_id&start&end&bucket` : le compteur `energy` étant **cumulatif**, l'endpoint renvoie les **deltas par bucket** (dernière valeur du bucket − ancre précédente, `clamp` ≥ 0), les totaux et le pic de puissance. Buckets alignés sur `start` → barres calées sur les jours **locaux**. Modèles `EnergySummary`/`EnergyBucket` + 2 tests unitaires.

### Frontend
- **`EnergyDashboard.svelte`** (réutilisable) : sélecteur Jour/Semaine/Mois + navigation, héros kWh + comparaison période précédente, tuiles (moyenne, production, pic, coût configurable), histogramme par sous-période avec tooltip, répartition par appareil.
- **`ConsommationsView`** : affiche le dashboard sur le board gris.
- **`EnergyDetailPage`** : repassée en thème clair (panneau puissance en direct + dashboard scopé au compteur). Corrige un `RangeError` quand `last_seen` est une `Date` invalide.
- **`CategoryRail`** : sélection « Tout / Aucun » par catégorie (page Sensors).
- Client `api/energy.ts` + handler mock.

### Décisions
- Coût : tarif 0,20 €/kWh par défaut, configurable (localStorage).
- Production affichée seulement si `produced_energy > 0`.
- Ancienne courbe de puissance instantanée retirée de `/consommations` au profit du dashboard.

### Tests
- `cargo test` : 145 OK · `svelte-check` : 0 erreur · vérifié visuellement (agrégé, détail, sélection catégorie) via captures headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)